### PR TITLE
let daemon be shut down before it has fully started

### DIFF
--- a/lbry/lbry/conf.py
+++ b/lbry/lbry/conf.py
@@ -362,6 +362,9 @@ class ConfigFileAccess:
         del self.data[key]
 
 
+TBC = typing.TypeVar('TBC', bound='BaseConfig')
+
+
 class BaseConfig:
 
     config = Path("Path to configuration file.", metavar='FILE')
@@ -418,7 +421,7 @@ class BaseConfig:
         }
 
     @classmethod
-    def create_from_arguments(cls, args):
+    def create_from_arguments(cls, args) -> TBC:
         conf = cls()
         conf.set_arguments(args)
         conf.set_environment()

--- a/lbry/lbry/extras/daemon/Component.py
+++ b/lbry/lbry/extras/daemon/Component.py
@@ -56,7 +56,8 @@ class Component(metaclass=ComponentType):
             self._running = True
             return result
         except asyncio.CancelledError:
-            pass
+            log.info("Cancelled setup of %s component", self.__class__.__name__)
+            raise
         except Exception as err:
             log.exception("Error setting up %s", self.component_name or self.__class__.__name__)
             raise err
@@ -67,7 +68,8 @@ class Component(metaclass=ComponentType):
             self._running = False
             return result
         except asyncio.CancelledError:
-            pass
+            log.info("Cancelled stop of %s component", self.__class__.__name__)
+            raise
         except Exception as err:
             log.exception("Error stopping %s", self.__class__.__name__)
             raise err

--- a/lbry/lbry/extras/daemon/Components.py
+++ b/lbry/lbry/extras/daemon/Components.py
@@ -168,7 +168,7 @@ class HeadersComponent(Component):
         }
         net = Network(ledger)
         first_connection = net.on_connected.first
-        asyncio.ensure_future(net.start())
+        asyncio.ensure_future(net.start())  # TODO: SKETCHY! it might be trapping a CancelledError and not raising it
         await first_connection
         remote_height = await net.get_server_height()
         await net.stop()

--- a/torba/torba/client/basenetwork.py
+++ b/torba/torba/client/basenetwork.py
@@ -3,6 +3,7 @@ import asyncio
 from asyncio import CancelledError
 from time import time
 from typing import List
+import socket
 
 from torba.rpc import RPCSession as BaseClientSession, Connector, RPCError
 
@@ -217,6 +218,8 @@ class SessionPool:
             log.warning("Timeout connecting to %s:%d", *session.server)
         except asyncio.CancelledError:  # pylint: disable=try-except-raise
             raise
+        except socket.gaierror:
+            log.warning("Could not resolve IP for %s", session.server[0])
         except Exception as err:  # pylint: disable=broad-except
             if 'Connect call failed' in str(err):
                 log.warning("Could not connect to %s:%d", *session.server)


### PR DESCRIPTION
There is more that can be improved here. Starting and stopping the daemon is still somewhat inconsistent. The daemon can shut down by raising SystemExit, or it shut down by raising GracefulExit. Is that right, or should there only be one way to do it?

fixes #2231 