### PR TITLE
Adds `comment abandon` command

### DIFF
--- a/lbry/lbry/extras/daemon/Daemon.py
+++ b/lbry/lbry/extras/daemon/Daemon.py
@@ -33,7 +33,7 @@ from lbry.extras.daemon.Components import EXCHANGE_RATE_MANAGER_COMPONENT, UPNP_
 from lbry.extras.daemon.ComponentManager import RequiredCondition
 from lbry.extras.daemon.ComponentManager import ComponentManager
 from lbry.extras.daemon.json_response_encoder import JSONResponseEncoder
-from lbry.extras.daemon.comment_client import jsonrpc_post, sign_comment, sign_abandon_comment
+from lbry.extras.daemon.comment_client import jsonrpc_post, sign_comment
 from lbry.extras.daemon.comment_client import is_comment_signed_by_channel
 from lbry.extras.daemon.undecorated import undecorated
 from lbry.wallet.transaction import Transaction, Output, Input
@@ -3521,7 +3521,7 @@ class Daemon(metaclass=JSONRPCServerType):
             'channel_id': channel.claim_id,
             'channel_name': channel.claim_name,
         })
-        sign_abandon_comment(abandon_comment_body, channel)
+        sign_comment(abandon_comment_body, channel, signing_field='comment_id')
         resp = await jsonrpc_post(self.conf.comment_server, 'delete_comment', abandon_comment_body)
         return {comment_id: resp}
 

--- a/lbry/lbry/extras/daemon/Daemon.py
+++ b/lbry/lbry/extras/daemon/Daemon.py
@@ -33,7 +33,8 @@ from lbry.extras.daemon.Components import EXCHANGE_RATE_MANAGER_COMPONENT, UPNP_
 from lbry.extras.daemon.ComponentManager import RequiredCondition
 from lbry.extras.daemon.ComponentManager import ComponentManager
 from lbry.extras.daemon.json_response_encoder import JSONResponseEncoder
-from lbry.extras.daemon.comment_client import jsonrpc_post, sign_comment, is_comment_signed_by_channel
+from lbry.extras.daemon.comment_client import jsonrpc_post, sign_comment, sign_abandon_comment
+from lbry.extras.daemon.comment_client import is_comment_signed_by_channel
 from lbry.extras.daemon.undecorated import undecorated
 from lbry.wallet.transaction import Transaction, Output, Input
 from lbry.wallet.account import Account as LBCAccount
@@ -3491,11 +3492,45 @@ class Daemon(metaclass=JSONRPCServerType):
                 'channel_name': channel.claim_name,
             })
             sign_comment(comment_body, channel)
-        response = await jsonrpc_post(self.conf.comment_server, 'create_comment', **comment_body)
+        response = await jsonrpc_post(self.conf.comment_server, 'create_comment', comment_body)
         if 'signature' in response:
             response['is_claim_signature_valid'] = is_comment_signed_by_channel(response, channel)
         return response
 
+    async def jsonrpc_comment_abandon(self, comment_id, channel_name=None, channel_id=None, channel_account_id=None):
+        """"
+        Delete a comment published under your channel identity
+
+        Usage:
+            comment_delete  (<comment_id> | --comment_id=<comment_id>)
+                            (--channel_id=<channel_id> | --channel_name=<channel_name>)
+                            [--channel_account_id=<channel_account_id>...]
+
+        Options:
+            --comment_id=<comment_id>                   : (str) The ID of the comment to be deleted.
+            --channel_id=<channel_id>                   : (str) The ID of the channel that posted the comment.
+            --channel_name=<channel_name>               : (str) The Name of the channel that posted the comment..
+            --channel_account_id=<channel_account_id>   : (str) one or more account ids for accounts to look in
+                                                          for channel certificates, defaults to all accounts.
+        Returns:
+        """
+        abandon_comment_body = {'comment_id': comment_id}
+        if not channel_name and not channel_id:
+            chan = await jsonrpc_post(
+                self.conf.comment_server, 'get_channel_from_comment_id', comment_id=comment_id
+            )
+            channel_id = chan.get('channel_id')
+            channel_name = chan.get('channel_name')
+
+        channel = await self.get_channel_or_none(channel_account_id, channel_id, channel_name, for_signing=True)
+        if not channel:
+            raise Exception('You must own the channel to delete the comment')
+        abandon_comment_body.update({
+            'channel_id': channel.claim_id,
+            'channel_name': channel.claim_name,
+        })
+        sign_abandon_comment(abandon_comment_body, channel)
+        return await jsonrpc_post(self.conf.comment_server, 'delete_comment', abandon_comment_body)
 
     async def broadcast_or_release(self, account, tx, blocking=False):
         try:

--- a/lbry/lbry/extras/daemon/comment_client.py
+++ b/lbry/lbry/extras/daemon/comment_client.py
@@ -36,23 +36,14 @@ def is_comment_signed_by_channel(comment: dict, channel: Output):
     return False
 
 
-def sign_comment(comment: dict, channel: Output):
+def sign_comment(comment: dict, channel: Output, signing_field='comment'):
     timestamp = str(int(time.time())).encode()
-    pieces = [timestamp, channel.claim_hash, comment['comment'].encode()]
+    pieces = [timestamp, channel.claim_hash, comment[signing_field].encode()]
     digest = sha256(b''.join(pieces))
     signature = channel.private_key.sign_digest_deterministic(digest, hashfunc=hashlib.sha256)
     comment.update({
         'signature': binascii.hexlify(signature).decode(),
         'signing_ts': timestamp.decode()
-    })
-
-
-def sign_abandon_comment(body: dict, channel: Output):
-    pieces = [body['comment_id'].encode(), channel.claim_hash]
-    digest = sha256(b''.join(pieces))
-    signature = channel.private_key.sign_digest_deterministic(digest, hashfunc=hashlib.sha256)
-    body.update({
-        'signature': binascii.hexlify(signature).decode()
     })
 
 

--- a/lbry/lbry/extras/daemon/comment_client.py
+++ b/lbry/lbry/extras/daemon/comment_client.py
@@ -48,7 +48,7 @@ def sign_comment(comment: dict, channel: Output, signing_field='comment'):
 
 
 async def jsonrpc_post(url: str, method: str, params: dict = None, **kwargs) -> any:
-    params = dict() if not params else params
+    params = params or {}
     params.update(kwargs)
     json_body = {'jsonrpc': '2.0', 'id': None, 'method': method, 'params': params}
     headers = {'Content-Type': 'application/json'}

--- a/lbry/tests/unit/comments/test_comment_signing.py
+++ b/lbry/tests/unit/comments/test_comment_signing.py
@@ -1,5 +1,5 @@
 from torba.testcase import AsyncioTestCase
-
+import hashlib
 from lbry.extras.daemon.comment_client import sign_comment
 from lbry.extras.daemon.comment_client import is_comment_signed_by_channel
 
@@ -14,7 +14,8 @@ class TestSigningComments(AsyncioTestCase):
             'claim_id': claim.claim_id,
             'channel_name': channel.claim_name,
             'channel_id': channel.claim_id,
-            'comment': comment
+            'comment': comment,
+            'comment_id': hashlib.sha256(comment.encode()).hexdigest()
         }
 
     def test01_successful_create_sign_and_validate_comment(self):
@@ -31,3 +32,28 @@ class TestSigningComments(AsyncioTestCase):
         comment = self.create_claim_comment_body('Woahh This is Sick!! Shout out 2 my boy Tommy H', stream, pdiddy)
         sign_comment(comment, channel2)
         self.assertFalse(is_comment_signed_by_channel(comment, pdiddy))
+
+    def test03_successful_sign_abandon_comment(self):
+        rswanson = get_channel('@RonSwanson')
+        dsilver = get_stream('Welcome to the Pawnee, and give a big round for Ron Swanson, AKA Duke Silver')
+        comment_body = self.create_claim_comment_body('COMPUTER, DELETE ALL VIDEOS OF RON.', dsilver, rswanson)
+        sign_comment(comment_body, rswanson, abandon=True)
+        self.assertTrue(is_comment_signed_by_channel(comment_body, rswanson, abandon=True))
+
+    def test04_invalid_signature(self):
+        rswanson = get_channel('@RonSwanson')
+        jeanralphio = get_channel('@JeanRalphio')
+        chair = get_stream('This is a nice chair. I made it with Mahogany wood and this electric saw')
+        chair_comment = self.create_claim_comment_body(
+            'Hah. You use an electric saw? Us swansons have been making chairs with handsaws just three after birth.',
+            chair,
+            rswanson
+        )
+        sign_comment(chair_comment, rswanson)
+        self.assertTrue(is_comment_signed_by_channel(chair_comment, rswanson))
+        self.assertFalse(is_comment_signed_by_channel(chair_comment, jeanralphio))
+        fake_abandon_signal = chair_comment.copy()
+        sign_comment(fake_abandon_signal, jeanralphio, abandon=True)
+        self.assertFalse(is_comment_signed_by_channel(fake_abandon_signal, rswanson, abandon=True))
+        self.assertFalse(is_comment_signed_by_channel(fake_abandon_signal, jeanralphio, abandon=True))
+


### PR DESCRIPTION
## Changes
Adds the command `comment_abandon` with the following signature:
```python
def comment_abandon(comment_id: str) -> dict:
    return {
        comment_id: {
            "deleted": bool
        }
    }
```

## Functionality
Accepts a `comment_id` and attempts to query the channel that the comment belongs to. 
If the user owns the channel, a signature is then made with the following encoding:
```
`comment_id` + `channel_claim_hash`
```
This signature is then validated by the comment server, returning the outcome of the request accordingly. 

###### TODO:
- Add unit tests