### PR TITLE
add granular balances

### DIFF
--- a/lbry/lbry/testcase.py
+++ b/lbry/lbry/testcase.py
@@ -156,6 +156,7 @@ class CommandTestCase(IntegrationTestCase):
         await self.on_transaction_id(txid)
         await self.generate(1)
         await self.on_transaction_id(txid)
+        return txid
 
     async def on_transaction_dict(self, tx):
         await self.ledger.wait(

--- a/lbry/lbry/wallet/account.py
+++ b/lbry/lbry/wallet/account.py
@@ -134,5 +134,8 @@ class Account(BaseAccount):
     def get_support_count(self, **constraints):
         return self.ledger.db.get_support_count(account=self, **constraints)
 
+    def get_support_summary(self):
+        return self.ledger.db.get_supports_summary(account_id=self.id)
+
     async def release_all_outputs(self):
         await self.ledger.db.release_all_outputs(self)

--- a/lbry/lbry/wallet/database.py
+++ b/lbry/lbry/wallet/database.py
@@ -138,3 +138,14 @@ class WalletDatabase(BaseDatabase):
             "    SELECT address from pubkey_address WHERE account = ?"
             "  )", [account.public_key.address]
         )
+
+    def get_supports_summary(self, account_id):
+        return self.db.execute_fetchall("""
+            select txo.amount, exists(select * from txi where txi.txoid=txo.txoid) as spent,
+                (txo.txid in
+                (select txi.txid from txi join pubkey_address a on txi.address = a.address
+                    where a.account = ?)) as from_me,
+                (txo.address in (select address from pubkey_address where account=?)) as to_me,
+                tx.height
+            from txo join tx using (txid) where is_support=1
+        """, (account_id, account_id))

--- a/lbry/tests/integration/test_chris45.py
+++ b/lbry/tests/integration/test_chris45.py
@@ -10,7 +10,7 @@ class EpicAdventuresOfChris45(CommandTestCase):
 
         # Chris45 starts everyday by checking his balance.
         result = await self.daemon.jsonrpc_account_balance()
-        self.assertEqual(result, '10.0')
+        self.assertEqual(result['available'], '10.0')
         # "10 LBC, yippy! I can do a lot with that.", he thinks to himself,
         # enthusiastically. But he is hungry so he goes into the kitchen
         # to make himself a spamdwich.
@@ -31,12 +31,12 @@ class EpicAdventuresOfChris45(CommandTestCase):
         # Chris doesn't sit idly by: he checks his balance!
 
         result = await self.daemon.jsonrpc_account_balance()
-        self.assertEqual(result, '8.989893')
+        self.assertEqual(result['available'], '8.989893')
 
         # He waits for 6 more blocks (confirmations) to make sure the balance has been settled.
         await self.generate(6)
         result = await self.daemon.jsonrpc_account_balance(confirmations=6)
-        self.assertEqual(result, '8.989893')
+        self.assertEqual(result['available'], '8.989893')
 
         # And is the channel resolvable and empty?
         response = await self.resolve('lbry://@spam')
@@ -59,7 +59,7 @@ class EpicAdventuresOfChris45(CommandTestCase):
         # He quickly checks the unconfirmed balance to make sure everything looks
         # correct.
         result = await self.daemon.jsonrpc_account_balance()
-        self.assertEqual(result, '7.969786')
+        self.assertEqual(result['available'], '7.969786')
 
         # Also checks that his new story can be found on the blockchain before
         # giving the link to all his friends.
@@ -70,7 +70,7 @@ class EpicAdventuresOfChris45(CommandTestCase):
         await self.generate(5)
         # When he comes back he verifies the confirmed balance.
         result = await self.daemon.jsonrpc_account_balance()
-        self.assertEqual(result, '7.969786')
+        self.assertEqual(result['available'], '7.969786')
 
         # As people start reading his story they discover some typos and notify
         # Chris who explains in despair "Oh! Noooooos!" but then remembers
@@ -93,7 +93,7 @@ class EpicAdventuresOfChris45(CommandTestCase):
         # After abandoning he just waits for his LBCs to be returned to his account
         await self.generate(5)
         result = await self.daemon.jsonrpc_account_balance()
-        self.assertEqual(result, '8.9693455')
+        self.assertEqual(result['available'], '8.9693455')
 
         # Amidst all this Chris receives a call from his friend Ramsey
         # who says that it is of utmost urgency that Chris transfer him
@@ -109,11 +109,11 @@ class EpicAdventuresOfChris45(CommandTestCase):
         await self.generate(5)
         result = await self.daemon.jsonrpc_account_balance()
         # Chris' balance was correct
-        self.assertEqual(result, '7.9692215')
+        self.assertEqual(result['available'], '7.9692215')
 
         # Ramsey too assured him that he had received the 1 LBC and thanks him
         result = await self.daemon.jsonrpc_account_balance(ramsey_account_id)
-        self.assertEqual(result, '1.0')
+        self.assertEqual(result['available'], '1.0')
 
         # After Chris is done with all the "helping other people" stuff he decides that it's time to
         # write a new story and publish it to lbry. All he needed was a fresh start and he came up with:

--- a/lbry/tests/integration/test_claim_commands.py
+++ b/lbry/tests/integration/test_claim_commands.py
@@ -602,15 +602,15 @@ class StreamCommands(ClaimTestCase):
         account2_id, account2 = new_account['id'], self.daemon.get_account_or_error(new_account['id'])
 
         await self.out(self.channel_create('@spam', '1.0'))
-        self.assertEqual('8.989893', await self.daemon.jsonrpc_account_balance())
+        self.assertEqual('8.989893', (await self.daemon.jsonrpc_account_balance())['available'])
 
         result = await self.out(self.daemon.jsonrpc_account_send(
             '5.0', await self.daemon.jsonrpc_address_unused(account2_id)
         ))
         await self.confirm_tx(result['txid'])
 
-        self.assertEqual('3.989769', await self.daemon.jsonrpc_account_balance())
-        self.assertEqual('5.0', await self.daemon.jsonrpc_account_balance(account2_id))
+        self.assertEqual('3.989769', (await self.daemon.jsonrpc_account_balance())['available'])
+        self.assertEqual('5.0', (await self.daemon.jsonrpc_account_balance(account2_id))['available'])
 
         baz_tx = await self.out(self.channel_create('@baz', '1.0', account_id=account2_id))
         baz_id = self.get_claim_id(baz_tx)

--- a/lbry/tests/integration/test_transaction_commands.py
+++ b/lbry/tests/integration/test_transaction_commands.py
@@ -36,3 +36,32 @@ class TransactionCommandsTestCase(CommandTestCase):
         await self.assertBalance(self.account, '0.0')
         await self.daemon.jsonrpc_utxo_release()
         await self.assertBalance(self.account, '11.0')
+
+    async def test_granular_balances(self):
+        initial_balance = await self.daemon.jsonrpc_account_balance()
+        self.assertEqual({
+            'tips_received': '0.0',
+            'tips_sent': '0.0',
+            'total': '10.0',
+            'available': '10.0',
+            'reserved': {'total': '0.0', 'claims': '0.0', 'supports': '0.0'}
+        }, initial_balance)
+        first_claim_id = self.get_claim_id(await self.stream_create('granularity', bid='3.0'))
+        await self.stream_update(first_claim_id, data=b'news', bid='1.0')
+        await self.support_create(first_claim_id, bid='2.0')
+        second_account_id = (await self.out(self.daemon.jsonrpc_account_create("Tip-er")))['id']
+        second_accound_address = await self.daemon.jsonrpc_address_unused(second_account_id)
+        await self.confirm_tx((await self.daemon.jsonrpc_account_send('1.0', second_accound_address)).id)
+        second_claim_id = self.get_claim_id(await self.stream_create(
+            name='granularity-is-cool', account_id=second_account_id, bid='0.1'))
+        await self.daemon.jsonrpc_support_create(second_claim_id, '0.5', tip=True)
+        await self.confirm_tx((await self.daemon.jsonrpc_support_create(
+            first_claim_id, '0.3', tip=True, account_id=second_account_id)).id)
+        final_balance = await self.daemon.jsonrpc_account_balance()
+        self.assertEqual({
+            'tips_received': '0.0',
+            'tips_sent': '0.0',
+            'total': '8.777264',
+            'available': '5.477264',
+            'reserved': {'claims': '1.0', 'supports': '2.3', 'total': '3.3'}
+        }, final_balance)

--- a/lbry/tests/integration/test_transaction_commands.py
+++ b/lbry/tests/integration/test_transaction_commands.py
@@ -59,8 +59,8 @@ class TransactionCommandsTestCase(CommandTestCase):
             first_claim_id, '0.3', tip=True, account_id=second_account_id)).id)
         final_balance = await self.daemon.jsonrpc_account_balance()
         self.assertEqual({
-            'tips_received': '0.0',
-            'tips_sent': '0.0',
+            'tips_received': '0.3',
+            'tips_sent': '0.5',
             'total': '8.777264',
             'available': '5.477264',
             'reserved': {'claims': '1.0', 'supports': '2.3', 'total': '3.3'}

--- a/lbry/tests/integration/test_transaction_commands.py
+++ b/lbry/tests/integration/test_transaction_commands.py
@@ -44,7 +44,7 @@ class TransactionCommandsTestCase(CommandTestCase):
             'tips_sent': '0.0',
             'total': '10.0',
             'available': '10.0',
-            'reserved': {'total': '0.0', 'claims': '0.0', 'supports': '0.0'}
+            'reserved': {'total': '0.0', 'claims': '0.0', 'supports': '0.0', 'tips': '0.0'}
         }, initial_balance)
         first_claim_id = self.get_claim_id(await self.stream_create('granularity', bid='3.0'))
         await self.stream_update(first_claim_id, data=b'news', bid='1.0')
@@ -52,16 +52,30 @@ class TransactionCommandsTestCase(CommandTestCase):
         second_account_id = (await self.out(self.daemon.jsonrpc_account_create("Tip-er")))['id']
         second_accound_address = await self.daemon.jsonrpc_address_unused(second_account_id)
         await self.confirm_tx((await self.daemon.jsonrpc_account_send('1.0', second_accound_address)).id)
+        self.assertEqual({
+            'tips_received': '0.0',
+            'tips_sent': '0.0',
+            'total': '8.97741',
+            'available': '5.97741',
+            'reserved': {'claims': '1.0', 'supports': '2.0', 'tips': '0.0', 'total': '3.0'}
+        }, await self.daemon.jsonrpc_account_balance())
         second_claim_id = self.get_claim_id(await self.stream_create(
             name='granularity-is-cool', account_id=second_account_id, bid='0.1'))
         await self.daemon.jsonrpc_support_create(second_claim_id, '0.5', tip=True)
-        await self.confirm_tx((await self.daemon.jsonrpc_support_create(
+        first_account_tip_txid = await self.confirm_tx((await self.daemon.jsonrpc_support_create(
             first_claim_id, '0.3', tip=True, account_id=second_account_id)).id)
-        final_balance = await self.daemon.jsonrpc_account_balance()
         self.assertEqual({
             'tips_received': '0.3',
             'tips_sent': '0.5',
             'total': '8.777264',
             'available': '5.477264',
-            'reserved': {'claims': '1.0', 'supports': '2.3', 'total': '3.3'}
-        }, final_balance)
+            'reserved': {'claims': '1.0', 'supports': '2.0', 'tips': '0.3', 'total': '3.3'}
+        }, await self.daemon.jsonrpc_account_balance())
+        await self.confirm_tx((await self.daemon.jsonrpc_support_abandon(txid=first_account_tip_txid, nout=0)).id)
+        self.assertEqual({
+            'tips_received': '0.3',
+            'tips_sent': '0.5',
+            'total': '8.777157',
+            'available': '5.777157',
+            'reserved': {'claims': '1.0', 'supports': '2.0', 'tips': '0.0', 'total': '3.0'}
+        }, await self.daemon.jsonrpc_account_balance())


### PR DESCRIPTION
backwards-incompatible: `account balance` no longer returns an integer. It now returns a dictionary with granular balances. The integer it used to return is now under `available` key on that new dictionary format.