### PR TITLE
Add `connected_servers` field to wallet status and improve analytics for wallet related download errors

### DIFF
--- a/lbry/lbry/extras/daemon/Components.py
+++ b/lbry/lbry/extras/daemon/Components.py
@@ -239,7 +239,15 @@ class WalletComponent(Component):
             local_height = self.wallet_manager.ledger.headers.height
             remote_height = self.wallet_manager.ledger.network.remote_height
             best_hash = self.wallet_manager.get_best_blockhash()
+            server = self.wallet_manager.ledger.network.client.server
             return {
+                'connected_servers': [
+                    {
+                        'host': server[0],
+                        'port': server[1],
+                        'latency': 0  # TODO: use real latency
+                    }
+                ],
                 'blocks': max(local_height, 0),
                 'blocks_behind': max(remote_height - local_height, 0),
                 'best_blockhash': best_hash,

--- a/lbry/lbry/extras/daemon/Daemon.py
+++ b/lbry/lbry/extras/daemon/Daemon.py
@@ -747,6 +747,13 @@ class Daemon(metaclass=JSONRPCServerType):
                     'best_blockhash': (str) block hash of most recent block,
                     'is_encrypted': (bool),
                     'is_locked': (bool),
+                    'connected_servers': (list) [
+                        {
+                            'host': (str) server hostname,
+                            'port': (int) server port,
+                            'latency': (int) milliseconds
+                        }
+                    ],
                 },
                 'dht': {
                     'node_id': (str) lbry dht node id - hex encoded,

--- a/lbry/lbry/extras/daemon/analytics.py
+++ b/lbry/lbry/extras/daemon/analytics.py
@@ -51,7 +51,8 @@ def _download_properties(conf: Config, external_ip: str, resolve_duration: float
                          head_blob_hash: typing.Optional[str] = None,
                          head_blob_length: typing.Optional[int] = None,
                          head_blob_download_duration: typing.Optional[float] = None,
-                         error: typing.Optional[str] = None) -> typing.Dict:
+                         error: typing.Optional[str] = None,
+                         wallet_server: typing.Optional[str] = None) -> typing.Dict:
     return {
         "external_ip": external_ip,
         "download_id": download_id,
@@ -77,7 +78,8 @@ def _download_properties(conf: Config, external_ip: str, resolve_duration: float
         "head_blob_length": head_blob_length,
         "head_blob_duration": None if not head_blob_download_duration else round(head_blob_download_duration, 4),
 
-        "connection_failures_count": connection_failures_count
+        "connection_failures_count": connection_failures_count,
+        "wallet_server": wallet_server
     }
 
 
@@ -184,11 +186,12 @@ class AnalyticsManager:
                                        head_blob_hash: typing.Optional[str] = None,
                                        head_blob_length: typing.Optional[int] = None,
                                        head_blob_duration: typing.Optional[int] = None,
-                                       error: typing.Optional[str] = None):
+                                       error: typing.Optional[str] = None,
+                                       wallet_server: typing.Optional[str] = None):
         await self.track(self._event(TIME_TO_FIRST_BYTES, _download_properties(
             self.conf, self.external_ip, resolve_duration, total_duration, download_id, name, outpoint,
             found_peers_count, tried_peers_count, connection_failures_count, added_fixed_peers, fixed_peers_delay,
-            sd_hash, sd_download_duration, head_blob_hash, head_blob_length, head_blob_duration, error
+            sd_hash, sd_download_duration, head_blob_hash, head_blob_length, head_blob_duration, error, wallet_server
         )))
 
     async def send_download_finished(self, download_id, name, sd_hash):

--- a/lbry/lbry/extras/daemon/analytics.py
+++ b/lbry/lbry/extras/daemon/analytics.py
@@ -51,7 +51,7 @@ def _download_properties(conf: Config, external_ip: str, resolve_duration: float
                          head_blob_hash: typing.Optional[str] = None,
                          head_blob_length: typing.Optional[int] = None,
                          head_blob_download_duration: typing.Optional[float] = None,
-                         error: typing.Optional[str] = None,
+                         error: typing.Optional[str] = None, error_msg: typing.Optional[str] = None,
                          wallet_server: typing.Optional[str] = None) -> typing.Dict:
     return {
         "external_ip": external_ip,
@@ -59,6 +59,7 @@ def _download_properties(conf: Config, external_ip: str, resolve_duration: float
         "total_duration": round(total_duration, 4),
         "resolve_duration": None if not resolve_duration else round(resolve_duration, 4),
         "error": error,
+        "error_message": error_msg,
         'name': name,
         "outpoint": outpoint,
 
@@ -187,11 +188,13 @@ class AnalyticsManager:
                                        head_blob_length: typing.Optional[int] = None,
                                        head_blob_duration: typing.Optional[int] = None,
                                        error: typing.Optional[str] = None,
+                                       error_msg: typing.Optional[str] = None,
                                        wallet_server: typing.Optional[str] = None):
         await self.track(self._event(TIME_TO_FIRST_BYTES, _download_properties(
             self.conf, self.external_ip, resolve_duration, total_duration, download_id, name, outpoint,
             found_peers_count, tried_peers_count, connection_failures_count, added_fixed_peers, fixed_peers_delay,
-            sd_hash, sd_download_duration, head_blob_hash, head_blob_length, head_blob_duration, error, wallet_server
+            sd_hash, sd_download_duration, head_blob_hash, head_blob_length, head_blob_duration, error, error_msg,
+            wallet_server
         )))
 
     async def send_download_finished(self, download_id, name, sd_hash):

--- a/lbry/lbry/stream/stream_manager.py
+++ b/lbry/lbry/stream/stream_manager.py
@@ -464,6 +464,7 @@ class StreamManager:
                         None if not (stream and stream.descriptor) else stream.descriptor.blobs[0].length,
                         None if not stream else stream.downloader.time_to_first_bytes,
                         None if not error else error.__class__.__name__,
+                        None if not error else str(error),
                         None if not server else f"{server[0]}:{server[1]}"
                     )
                 )

--- a/lbry/lbry/stream/stream_manager.py
+++ b/lbry/lbry/stream/stream_manager.py
@@ -448,6 +448,7 @@ class StreamManager:
         finally:
             if self.analytics_manager and (error or (stream and (stream.downloader.time_to_descriptor or
                                                                  stream.downloader.time_to_first_bytes))):
+                server = self.wallet.ledger.network.client.server
                 self.loop.create_task(
                     self.analytics_manager.send_time_to_first_bytes(
                         resolved_time, self.loop.time() - start_time, None if not stream else stream.download_id,
@@ -462,7 +463,8 @@ class StreamManager:
                         None if not (stream and stream.descriptor) else stream.descriptor.blobs[0].blob_hash,
                         None if not (stream and stream.descriptor) else stream.descriptor.blobs[0].length,
                         None if not stream else stream.downloader.time_to_first_bytes,
-                        None if not error else error.__class__.__name__
+                        None if not error else error.__class__.__name__,
+                        None if not server else f"{server[0]}:{server[1]}"
                     )
                 )
 


### PR DESCRIPTION
- fixes https://github.com/lbryio/lbry-sdk/issues/2380
- fixes  https://github.com/lbryio/lbry-sdk/issues/2381
- add `wallet_server` and `error_message` to time to first bytes analytics event