### PR TITLE
Throttle concurrent blob downloads

### DIFF
--- a/lbry/lbry/blob/writer.py
+++ b/lbry/lbry/blob/writer.py
@@ -1,16 +1,17 @@
 import typing
 import logging
-import asyncio
 from io import BytesIO
 from lbry.error import InvalidBlobHashError, InvalidDataError
 from lbry.cryptoutils import get_lbry_hash_obj
+if typing.TYPE_CHECKING:
+    import asyncio
 
 log = logging.getLogger(__name__)
 
 
 class HashBlobWriter:
     def __init__(self, expected_blob_hash: str, get_length: typing.Callable[[], int],
-                 finished: asyncio.Future):
+                 finished: 'asyncio.Future[bytes]'):
         self.expected_blob_hash = expected_blob_hash
         self.get_length = get_length
         self.buffer = BytesIO()

--- a/lbry/lbry/blob_exchange/client.py
+++ b/lbry/lbry/blob_exchange/client.py
@@ -85,6 +85,7 @@ class BlobExchangeClientProtocol(asyncio.Protocol):
         self._blob_bytes_received += len(data)
         try:
             self.writer.write(data)
+
         except IOError as err:
             log.error("error downloading blob from %s:%i: %s", self.peer_address, self.peer_port, err)
             if self._response_fut and not self._response_fut.done():
@@ -180,7 +181,7 @@ class BlobExchangeClientProtocol(asyncio.Protocol):
             return 0, self.transport
         try:
             self._blob_bytes_received = 0
-            self.blob, self.writer = blob, blob.get_blob_writer(self.peer_address, self.peer_port)
+            self.blob, self.writer = blob, blob.get_blob_writer(self.transport)
             self._response_fut = asyncio.Future(loop=self.loop)
             return await self._download_blob()
         except OSError:

--- a/lbry/lbry/stream/reflector/server.py
+++ b/lbry/lbry/stream/reflector/server.py
@@ -72,7 +72,7 @@ class ReflectorServerProtocol(asyncio.Protocol):
                 return
             self.sd_blob = self.blob_manager.get_blob(request['sd_blob_hash'], request['sd_blob_size'])
             if not self.sd_blob.get_is_verified():
-                self.writer = self.sd_blob.get_blob_writer(self.transport.get_extra_info('peername'))
+                self.writer = self.sd_blob.get_blob_writer(self.transport)
                 self.incoming.set()
                 self.send_response({"send_sd_blob": True})
                 try:
@@ -111,7 +111,7 @@ class ReflectorServerProtocol(asyncio.Protocol):
                 return
             blob = self.blob_manager.get_blob(request['blob_hash'], request['blob_size'])
             if not blob.get_is_verified():
-                self.writer = blob.get_blob_writer(self.transport.get_extra_info('peername'))
+                self.writer = blob.get_blob_writer(self.transport)
                 self.incoming.set()
                 self.send_response({"send_blob": True})
                 try:

--- a/lbry/tests/unit/blob_exchange/test_transfer_blob.py
+++ b/lbry/tests/unit/blob_exchange/test_transfer_blob.py
@@ -135,12 +135,15 @@ class TestBlobExchange(BlobExchangeTestBase):
             write_blob(blob_bytes)
         blob._write_blob = wrap_write_blob
 
-        writer1 = blob.get_blob_writer(peer_port=1)
-        writer2 = blob.get_blob_writer(peer_port=2)
+        t1 = asyncio.Transport()
+        t2 = asyncio.Transport()
+
+        writer1 = blob.get_blob_writer(t1)
+        writer2 = blob.get_blob_writer(t2)
         reader1_ctx_before_write = blob.reader_context()
 
         with self.assertRaises(OSError):
-            blob.get_blob_writer(peer_port=2)
+            blob.get_blob_writer(t2)
         with self.assertRaises(OSError):
             with blob.reader_context():
                 pass

--- a/lbry/tests/unit/blob_exchange/test_transfer_blob.py
+++ b/lbry/tests/unit/blob_exchange/test_transfer_blob.py
@@ -137,6 +137,10 @@ class TestBlobExchange(BlobExchangeTestBase):
 
         t1 = asyncio.Transport()
         t2 = asyncio.Transport()
+        t1.pause_reading = lambda: None
+        t1.resume_reading = lambda: None
+        t2.pause_reading = lambda: None
+        t2.resume_reading = lambda: None
 
         writer1 = blob.get_blob_writer(t1)
         writer2 = blob.get_blob_writer(t2)


### PR DESCRIPTION
pause other blob exchange transports for a given blob during a download once one of them has written 64k bytes. If this download subsequently fails, resume the other transports.