### PR TITLE
Strips comment before signing

### DIFF
--- a/lbry/lbry/extras/daemon/Daemon.py
+++ b/lbry/lbry/extras/daemon/Daemon.py
@@ -3591,7 +3591,7 @@ class Daemon(metaclass=JSONRPCServerType):
             }
         """
         comment_body = {
-            'comment': comment,
+            'comment': comment.strip(),
             'claim_id': claim_id,
             'parent_id': parent_id,
         }


### PR DESCRIPTION
Strips whitespace off the comment *before* it gets sent to the server. 