### PR TITLE
Enable to set max_key_fee to null via cli

### DIFF
--- a/lbry/lbry/conf.py
+++ b/lbry/lbry/conf.py
@@ -148,7 +148,10 @@ class MaxKeyFee(Setting[dict]):
 
     @staticmethod
     def _parse_list(l):
-        assert len(l) == 2, 'Max key fee is made up of two values: "AMOUNT CURRENCY".'
+        if len(l) == 1 and (l[0] == 'null' or not l[0]):
+            return None
+        assert len(l) == 2, ('Max key fee is made up of either two values: '
+                             '"AMOUNT CURRENCY", or "null" (to set no limit)')
         try:
             amount = float(l[0])
         except ValueError:
@@ -159,8 +162,8 @@ class MaxKeyFee(Setting[dict]):
         return {'amount': amount, 'currency': currency}
 
     def deserialize(self, value):
-        if value is None:
-            return
+        if not value:
+            return None
         if isinstance(value, dict):
             return {
                 'currency': value['currency'],
@@ -176,7 +179,7 @@ class MaxKeyFee(Setting[dict]):
         parser.add_argument(
             self.cli_name,
             help=self.doc,
-            nargs=2,
+            nargs='+',
             metavar=('AMOUNT', 'CURRENCY'),
             default=NOT_SET
         )
@@ -527,7 +530,8 @@ class Config(CLIConfig):
         "peers are not found or are slow", 2.0
     )
     max_key_fee = MaxKeyFee(
-        "Don't download streams with fees exceeding this amount", {'currency': 'USD', 'amount': 50.0}
+        "Don't download streams with fees exceeding this amount. When set to "
+        "null, the amount is unbounded.", {'currency': 'USD', 'amount': 50.0}
     )
 
     # reflector settings

--- a/lbry/lbry/conf.py
+++ b/lbry/lbry/conf.py
@@ -148,10 +148,12 @@ class MaxKeyFee(Setting[dict]):
 
     @staticmethod
     def _parse_list(l):
-        if len(l) == 1 and (l[0] == 'null' or not l[0]):
+        if len(l) == 1 and l[0] == 'null':
             return None
-        assert len(l) == 2, ('Max key fee is made up of either two values: '
-                             '"AMOUNT CURRENCY", or "null" (to set no limit)')
+        assert len(l) == 2, (
+            'Max key fee is made up of either two values: '
+            '"AMOUNT CURRENCY", or "null" (to set no limit)'
+        )
         try:
             amount = float(l[0])
         except ValueError:
@@ -162,8 +164,8 @@ class MaxKeyFee(Setting[dict]):
         return {'amount': amount, 'currency': currency}
 
     def deserialize(self, value):
-        if not value:
-            return None
+        if value is None:
+            return
         if isinstance(value, dict):
             return {
                 'currency': value['currency'],

--- a/lbry/lbry/conf.py
+++ b/lbry/lbry/conf.py
@@ -148,7 +148,7 @@ class MaxKeyFee(Setting[dict]):
 
     @staticmethod
     def _parse_list(l):
-        if len(l) == 1 and l[0] == 'null':
+        if l == ['null']:
             return None
         assert len(l) == 2, (
             'Max key fee is made up of either two values: '

--- a/lbry/tests/unit/test_conf.py
+++ b/lbry/tests/unit/test_conf.py
@@ -207,6 +207,11 @@ class ConfigurationTests(unittest.TestCase):
                 c.max_key_fee = None
             with open(config, 'r') as fd:
                 self.assertEqual(fd.read(), 'max_key_fee: null\n')
+            c = Config.create_from_arguments(
+                types.SimpleNamespace(config=config)
+            )
+            with open(config, 'r') as fd:
+                self.assertEqual(c.max_key_fee, None)
 
     def test_max_key_fee_from_args(self):
         parser = argparse.ArgumentParser()
@@ -219,6 +224,14 @@ class ConfigurationTests(unittest.TestCase):
 
         # disabled
         args = parser.parse_args(['--no-max-key-fee'])
+        c = Config.create_from_arguments(args)
+        self.assertEqual(c.max_key_fee, None)
+
+        args = parser.parse_args(['--max-key-fee', 'null'])
+        c = Config.create_from_arguments(args)
+        self.assertEqual(c.max_key_fee, None)
+
+        args = parser.parse_args(['--max-key-fee', ''])
         c = Config.create_from_arguments(args)
         self.assertEqual(c.max_key_fee, None)
 

--- a/lbry/tests/unit/test_conf.py
+++ b/lbry/tests/unit/test_conf.py
@@ -231,10 +231,6 @@ class ConfigurationTests(unittest.TestCase):
         c = Config.create_from_arguments(args)
         self.assertEqual(c.max_key_fee, None)
 
-        args = parser.parse_args(['--max-key-fee', ''])
-        c = Config.create_from_arguments(args)
-        self.assertEqual(c.max_key_fee, None)
-
         # set
         args = parser.parse_args(['--max-key-fee', '1.0', 'BTC'])
         c = Config.create_from_arguments(args)

--- a/lbry/tests/unit/test_conf.py
+++ b/lbry/tests/unit/test_conf.py
@@ -207,11 +207,6 @@ class ConfigurationTests(unittest.TestCase):
                 c.max_key_fee = None
             with open(config, 'r') as fd:
                 self.assertEqual(fd.read(), 'max_key_fee: null\n')
-            c = Config.create_from_arguments(
-                types.SimpleNamespace(config=config)
-            )
-            with open(config, 'r') as fd:
-                self.assertEqual(c.max_key_fee, None)
 
     def test_max_key_fee_from_args(self):
         parser = argparse.ArgumentParser()


### PR DESCRIPTION
This fix is meant to address #2050. Instead letting argparse check the number of arguments, the arguments are cast to a list whose length is checked in `_parse_list()`. It was tested via both CLI and yaml, and I extended some of the unit tests in `test_conf.py`.