### PR TITLE
Log inaccessible downloads / wallet path, switch to default if possible

### DIFF
--- a/lbry/lbry/extras/cli.py
+++ b/lbry/lbry/extras/cli.py
@@ -276,14 +276,15 @@ def run_daemon(args: argparse.Namespace, conf: Config):
     if hasattr(loop, 'shutdown_asyncgens'):
         loop.run_until_complete(loop.shutdown_asyncgens())
 
+
 def prepare_directory(dir_path: str):
     if not os.path.isdir(dir_path):
         pathlib.Path(dir_path).mkdir(parents=True, exist_ok=True)
-    testfile = tempfile.TemporaryFile(dir=dir_path)
-    testfile.close()
+    tempfile.TemporaryFile(dir=dir_path).close()
+    return dir_path
 
 
-def change_to_default_if_inaccessible(parsed_path: str, path_obj: Path, conf: Config):
+def change_to_default_if_inaccessible(parsed_path: str, path_obj: Path):
     assert path_obj.metavar in ('DIR', 'FILE'), "Path must be either to a directory or a file"
     handled_errors = (OSError, IOError, PermissionError)
     is_file = path_obj.metavar == 'FILE'
@@ -291,15 +292,14 @@ def change_to_default_if_inaccessible(parsed_path: str, path_obj: Path, conf: Co
     dir_path = os.path.basename(parsed_path) if is_file else parsed_path
     default_dir_path = os.path.basename(default_path) if is_file else default_path
     try:
-        prepare_directory(dir_path)
+        return prepare_directory(dir_path)
     except handled_errors:
         log.warning("Failed to access %s, setting to %s", dir_path, default_dir_path)
-        setattr(conf, path_obj.name, default_dir_path)
-        try:
-            prepare_directory(default_dir_path)
-        except handled_errors as e:
-            log.critical("Failed to access both %s and %s", dir_path, default_dir_path)
-            raise e
+    try:
+        return prepare_directory(default_dir_path)
+    except handled_errors:
+        log.critical("Failed to access both %s and %s", dir_path, default_dir_path)
+        raise
 
 
 def main(argv=None):
@@ -309,10 +309,10 @@ def main(argv=None):
 
     conf = Config.create_from_arguments(args)
 
-    change_to_default_if_inaccessible(conf.data_dir, Config.data_dir, conf)
-    change_to_default_if_inaccessible(conf.config, Config.config, conf)
-    change_to_default_if_inaccessible(conf.download_dir, Config.download_dir, conf)
-    change_to_default_if_inaccessible(conf.wallet_dir, Config.wallet_dir, conf)
+    conf.data_dir = change_to_default_if_inaccessible(conf.data_dir, Config.data_dir)
+    conf.config = change_to_default_if_inaccessible(conf.config, Config.config)
+    conf.download_dir = change_to_default_if_inaccessible(conf.download_dir, Config.download_dir)
+    conf.wallet_dit = change_to_default_if_inaccessible(conf.wallet_dir, Config.wallet_dir)
 
     if args.cli_version:
         print(f"lbrynet {lbrynet_version}")

--- a/lbry/lbry/extras/cli.py
+++ b/lbry/lbry/extras/cli.py
@@ -312,7 +312,7 @@ def main(argv=None):
     conf.data_dir = change_to_default_if_inaccessible(conf.data_dir, Config.data_dir)
     conf.config = change_to_default_if_inaccessible(conf.config, Config.config)
     conf.download_dir = change_to_default_if_inaccessible(conf.download_dir, Config.download_dir)
-    conf.wallet_dit = change_to_default_if_inaccessible(conf.wallet_dir, Config.wallet_dir)
+    conf.wallet_dir = change_to_default_if_inaccessible(conf.wallet_dir, Config.wallet_dir)
 
     if args.cli_version:
         print(f"lbrynet {lbrynet_version}")


### PR DESCRIPTION
fixes #877. If any of download or wallet directories are not writable, then an attempt to set corresponding path to the default is made, and if unsuccessful, the app is shut down. Either case is logged into the log file. This was tested manually, and original unit tests seem to be passing.

In accordance with Pythonic EAFP, to test if directory is writable, I just write to it. It does not look pretty, but it has the benefit that it all the other cases, e.g. there is not enough space on the disk. Just checking the permissions might look nicer.

Should I also cover the case that even the log file is not accessible and logs should be just sent to stdout? Or is it OK to just throw an exception and not start?

Please, let me know if this is desired behavior, and if this is even a step in good direction before I start writing tests.