### PR TITLE
Fix docopt for `claim_search`

### DIFF
--- a/lbry/lbry/extras/daemon/Daemon.py
+++ b/lbry/lbry/extras/daemon/Daemon.py
@@ -1775,7 +1775,8 @@ class Daemon(metaclass=JSONRPCServerType):
 
         Usage:
             claim_search [<name> | --name=<name>] [--claim_id=<claim_id>] [--txid=<txid>] [--nout=<nout>]
-                         [--channel=<channel> | --channel_ids=<channel_ids>... --not_channel_ids=<not_channel_ids>...]
+                         [--channel=<channel> |
+                             [[--channel_ids=<channel_ids>...] [--not_channel_ids=<not_channel_ids>...]]]
                          [--has_channel_signature] [--valid_channel_signature | --invalid_channel_signature]
                          [--is_controlling] [--release_time=<release_time>] [--public_key_id=<public_key_id>]
                          [--timestamp=<timestamp>] [--creation_timestamp=<creation_timestamp>]


### PR DESCRIPTION
There seems to have been missing brackets for `channel_ids` and `not_channel_ids` arguments in `claim_search` docstring. Grouping them together using `[]` (as they are optional) seems to have fixed #2405.