### PR TITLE
Channel claims and certificates no longer need to be in the same account to sign stream claims.

### DIFF
--- a/lbry/lbry/extras/daemon/Daemon.py
+++ b/lbry/lbry/extras/daemon/Daemon.py
@@ -2317,6 +2317,7 @@ class Daemon(metaclass=JSONRPCServerType):
                 })
                 if self.ledger.network.is_connected:
                     await self.ledger.subscribe_account(account)
+                    await self.ledger._update_tasks.done.wait()
             # Case 3: the holding address has changed and we can't create or find an account for it
             else:
                 raise Exception(

--- a/lbry/lbry/extras/daemon/json_response_encoder.py
+++ b/lbry/lbry/extras/daemon/json_response_encoder.py
@@ -184,6 +184,8 @@ class JSONResponseEncoder(JSONEncoder):
                     output['value_type'] = txo.claim.claim_type
                     if self.include_protobuf:
                         output['protobuf'] = hexlify(txo.claim.to_bytes())
+                    if txo.claim.is_channel:
+                        output['has_signing_key'] = txo.has_private_key
                     if check_signature and txo.claim.is_signed:
                         if txo.channel is not None:
                             output['signing_channel'] = self.encode_output(txo.channel)

--- a/lbry/lbry/wallet/constants.py
+++ b/lbry/lbry/wallet/constants.py
@@ -1,0 +1,5 @@
+TXO_TYPES = {
+    "stream": 1,
+    "channel": 2,
+    "support": 3
+}

--- a/lbry/lbry/wallet/database.py
+++ b/lbry/lbry/wallet/database.py
@@ -39,7 +39,10 @@ class WalletDatabase(BaseDatabase):
     def txo_to_row(self, tx, address, txo):
         row = super().txo_to_row(tx, address, txo)
         if txo.is_claim:
-            row['txo_type'] = TXO_TYPES.get(txo.claim.claim_type, 0)
+            if txo.can_decode_claim:
+                row['txo_type'] = TXO_TYPES.get(txo.claim.claim_type, TXO_TYPES['stream'])
+            else:
+                row['txo_type'] = TXO_TYPES['stream']
         elif txo.is_support:
             row['txo_type'] = TXO_TYPES['support']
         if txo.script.is_claim_involved:

--- a/lbry/lbry/wallet/database.py
+++ b/lbry/lbry/wallet/database.py
@@ -3,6 +3,7 @@ from typing import List
 from torba.client.basedatabase import BaseDatabase
 
 from lbry.wallet.transaction import Output
+from lbry.wallet.constants import TXO_TYPES
 
 
 class WalletDatabase(BaseDatabase):
@@ -17,15 +18,12 @@ class WalletDatabase(BaseDatabase):
             script blob not null,
             is_reserved boolean not null default 0,
 
+            txo_type integer not null default 0,
             claim_id text,
-            claim_name text,
-            is_claim boolean not null default 0,
-            is_update boolean not null default 0,
-            is_support boolean not null default 0,
-            is_buy boolean not null default 0,
-            is_sell boolean not null default 0
+            claim_name text
         );
         create index if not exists txo_claim_id_idx on txo (claim_id);
+        create index if not exists txo_txo_type_idx on txo (txo_type);
     """
 
     CREATE_TABLES_QUERY = (
@@ -40,13 +38,10 @@ class WalletDatabase(BaseDatabase):
 
     def txo_to_row(self, tx, address, txo):
         row = super().txo_to_row(tx, address, txo)
-        row.update({
-            'is_claim': txo.script.is_claim_name,
-            'is_update': txo.script.is_update_claim,
-            'is_support': txo.script.is_support_claim,
-            'is_buy': txo.script.is_buy_claim,
-            'is_sell': txo.script.is_sell_claim,
-        })
+        if txo.is_claim:
+            row['txo_type'] = TXO_TYPES.get(txo.claim.claim_type, 0)
+        elif txo.is_support:
+            row['txo_type'] = TXO_TYPES['support']
         if txo.script.is_claim_involved:
             row['claim_id'] = txo.claim_id
             row['claim_name'] = txo.claim_name
@@ -87,7 +82,9 @@ class WalletDatabase(BaseDatabase):
 
     @staticmethod
     def constrain_claims(constraints):
-        constraints['claim_type__any'] = {'is_claim': 1, 'is_update': 1}
+        constraints['txo_type__in'] = [
+            TXO_TYPES['stream'], TXO_TYPES['channel']
+        ]
 
     async def get_claims(self, **constraints) -> List[Output]:
         self.constrain_claims(constraints)
@@ -99,8 +96,7 @@ class WalletDatabase(BaseDatabase):
 
     @staticmethod
     def constrain_streams(constraints):
-        if 'claim_name' not in constraints or 'claim_id' not in constraints:
-            constraints['claim_name__not_like'] = '@%'
+        constraints['txo_type'] = TXO_TYPES['stream']
 
     def get_streams(self, **constraints):
         self.constrain_streams(constraints)
@@ -112,8 +108,7 @@ class WalletDatabase(BaseDatabase):
 
     @staticmethod
     def constrain_channels(constraints):
-        if 'claim_name' not in constraints or 'claim_id' not in constraints:
-            constraints['claim_name__like'] = '@%'
+        constraints['txo_type'] = TXO_TYPES['channel']
 
     def get_channels(self, **constraints):
         self.constrain_channels(constraints)
@@ -125,7 +120,7 @@ class WalletDatabase(BaseDatabase):
 
     @staticmethod
     def constrain_supports(constraints):
-        constraints['is_support'] = 1
+        constraints['txo_type'] = TXO_TYPES['support']
 
     def get_supports(self, **constraints):
         self.constrain_supports(constraints)
@@ -144,12 +139,12 @@ class WalletDatabase(BaseDatabase):
         )
 
     def get_supports_summary(self, account_id):
-        return self.db.execute_fetchall("""
+        return self.db.execute_fetchall(f"""
             select txo.amount, exists(select * from txi where txi.txoid=txo.txoid) as spent,
                 (txo.txid in
                 (select txi.txid from txi join pubkey_address a on txi.address = a.address
                     where a.account = ?)) as from_me,
                 (txo.address in (select address from pubkey_address where account=?)) as to_me,
                 tx.height
-            from txo join tx using (txid) where is_support=1
+            from txo join tx using (txid) where txo_type={TXO_TYPES['support']}
         """, (account_id, account_id))

--- a/lbry/lbry/wallet/ledger.py
+++ b/lbry/lbry/wallet/ledger.py
@@ -110,7 +110,7 @@ class MainNetLedger(BaseLedger):
 
     @staticmethod
     def constraint_spending_utxos(constraints):
-        constraints.update({'is_claim': 0, 'is_update': 0, 'is_support': 0})
+        constraints['txo_type'] = 0
 
     def get_utxos(self, **constraints):
         self.constraint_spending_utxos(constraints)

--- a/torba/torba/client/basedatabase.py
+++ b/torba/torba/client/basedatabase.py
@@ -3,7 +3,7 @@ import asyncio
 from binascii import hexlify
 from concurrent.futures.thread import ThreadPoolExecutor
 
-from typing import Tuple, List, Union, Callable, Any, Awaitable, Iterable
+from typing import Tuple, List, Union, Callable, Any, Awaitable, Iterable, Optional
 
 import sqlite3
 
@@ -216,7 +216,7 @@ def rows_to_dict(rows, fields):
 
 class SQLiteMixin:
 
-    SCHEMA_VERSION: str = None
+    SCHEMA_VERSION: Optional[str] = None
     CREATE_TABLES_QUERY: str
     MAX_QUERY_VARIABLES = 900
 

--- a/torba/torba/client/baseledger.py
+++ b/torba/torba/client/baseledger.py
@@ -230,6 +230,8 @@ class BaseLedger(metaclass=LedgerRegistry):
         return self.release_outputs([txi.txo_ref.txo for txi in tx.inputs])
 
     def constraint_account_or_all(self, constraints):
+        if 'accounts' in constraints:
+            return
         account = constraints.pop('account', None)
         if account:
             constraints['accounts'] = [account]


### PR DESCRIPTION
release-text: This release includes changes to the client wallet database structure and will require a full re-sync of your transactions; this will happen automatically on startup.