### PR TITLE
wallet server: add options to set server description, payment address and daily fee

### DIFF
--- a/torba/tests/client_tests/integration/test_network.py
+++ b/torba/tests/client_tests/integration/test_network.py
@@ -30,7 +30,7 @@ class NetworkTests(IntegrationTestCase):
                           'server_version': '0.5.7'}, await self.ledger.network.get_server_features())
         await self.conductor.spv_node.stop()
         address = (await self.account.get_addresses(limit=1))[0]
-        os.environ.update({'DESCRIPTION': 'Fastest server in the west.', 'PAYMENT_ADDRESS': address, 'DAILY_FEE': '42'})
+        os.environ.update({'DESCRIPTION': 'Fastest server in the west.', 'DONATION_ADDRESS': address, 'DAILY_FEE': '42'})
         await self.conductor.spv_node.start(self.conductor.blockchain_node)
         await self.ledger.network.on_connected.first
         self.assertEqual({'genesis_hash': self.conductor.spv_node.coin_class.GENESIS_HASH,

--- a/torba/tests/client_tests/integration/test_network.py
+++ b/torba/tests/client_tests/integration/test_network.py
@@ -1,4 +1,5 @@
 import logging
+import os
 import asyncio
 from unittest.mock import Mock
 
@@ -15,6 +16,33 @@ class NetworkTests(IntegrationTestCase):
         await self.blockchain.generate(1)
         await self.ledger.network.on_header.first
         self.assertEqual(self.ledger.network.remote_height, initial_height + 1)
+
+    async def test_server_features(self):
+        self.assertEqual({'genesis_hash': self.conductor.spv_node.coin_class.GENESIS_HASH,
+                          'hash_function': 'sha256',
+                          'hosts': {},
+                          'protocol_max': '1.4',
+                          'protocol_min': '1.1',
+                          'pruning': None,
+                          'description': '',
+                          'payment_address': '',
+                          'daily_fee': 0,
+                          'server_version': '0.5.7'}, await self.ledger.network.get_server_features())
+        await self.conductor.spv_node.stop()
+        address = (await self.account.get_addresses(limit=1))[0]
+        os.environ.update({'DESCRIPTION': 'Fastest server in the west.', 'PAYMENT_ADDRESS': address, 'DAILY_FEE': '42'})
+        await self.conductor.spv_node.start(self.conductor.blockchain_node)
+        await self.ledger.network.on_connected.first
+        self.assertEqual({'genesis_hash': self.conductor.spv_node.coin_class.GENESIS_HASH,
+                          'hash_function': 'sha256',
+                          'hosts': {},
+                          'protocol_max': '1.4',
+                          'protocol_min': '1.1',
+                          'pruning': None,
+                          'description': 'Fastest server in the west.',
+                          'payment_address': address,
+                          'daily_fee': 42,
+                          'server_version': '0.5.7'}, await self.ledger.network.get_server_features())
 
 
 class ReconnectTests(IntegrationTestCase):

--- a/torba/tests/client_tests/integration/test_network.py
+++ b/torba/tests/client_tests/integration/test_network.py
@@ -18,31 +18,36 @@ class NetworkTests(IntegrationTestCase):
         self.assertEqual(self.ledger.network.remote_height, initial_height + 1)
 
     async def test_server_features(self):
-        self.assertEqual({'genesis_hash': self.conductor.spv_node.coin_class.GENESIS_HASH,
-                          'hash_function': 'sha256',
-                          'hosts': {},
-                          'protocol_max': '1.4',
-                          'protocol_min': '1.1',
-                          'pruning': None,
-                          'description': '',
-                          'payment_address': '',
-                          'daily_fee': 0,
-                          'server_version': '0.5.7'}, await self.ledger.network.get_server_features())
+        self.assertEqual({
+            'genesis_hash': self.conductor.spv_node.coin_class.GENESIS_HASH,
+            'hash_function': 'sha256',
+            'hosts': {},
+            'protocol_max': '1.4',
+            'protocol_min': '1.1',
+            'pruning': None,
+            'description': '',
+            'payment_address': '',
+            'daily_fee': 0,
+            'server_version': '0.5.7'}, await self.ledger.network.get_server_features())
         await self.conductor.spv_node.stop()
         address = (await self.account.get_addresses(limit=1))[0]
-        os.environ.update({'DESCRIPTION': 'Fastest server in the west.', 'DONATION_ADDRESS': address, 'DAILY_FEE': '42'})
+        os.environ.update({
+            'DESCRIPTION': 'Fastest server in the west.',
+            'DONATION_ADDRESS': address,
+            'DAILY_FEE': '42'})
         await self.conductor.spv_node.start(self.conductor.blockchain_node)
         await self.ledger.network.on_connected.first
-        self.assertEqual({'genesis_hash': self.conductor.spv_node.coin_class.GENESIS_HASH,
-                          'hash_function': 'sha256',
-                          'hosts': {},
-                          'protocol_max': '1.4',
-                          'protocol_min': '1.1',
-                          'pruning': None,
-                          'description': 'Fastest server in the west.',
-                          'payment_address': address,
-                          'daily_fee': 42,
-                          'server_version': '0.5.7'}, await self.ledger.network.get_server_features())
+        self.assertEqual({
+            'genesis_hash': self.conductor.spv_node.coin_class.GENESIS_HASH,
+            'hash_function': 'sha256',
+            'hosts': {},
+            'protocol_max': '1.4',
+            'protocol_min': '1.1',
+            'pruning': None,
+            'description': 'Fastest server in the west.',
+            'payment_address': address,
+            'daily_fee': 42,
+            'server_version': '0.5.7'}, await self.ledger.network.get_server_features())
 
 
 class ReconnectTests(IntegrationTestCase):

--- a/torba/torba/client/basenetwork.py
+++ b/torba/torba/client/basenetwork.py
@@ -258,6 +258,9 @@ class BaseNetwork:
                 self.client.abort()
             raise asyncio.CancelledError()
 
+    def get_server_features(self):
+        return self.rpc('server.features', (), restricted=True)
+
 
 class SessionPool:
 

--- a/torba/torba/server/env.py
+++ b/torba/torba/server/env.py
@@ -80,6 +80,9 @@ class Env:
         self.bandwidth_limit = self.integer('BANDWIDTH_LIMIT', 2000000)
         self.session_timeout = self.integer('SESSION_TIMEOUT', 600)
         self.drop_client = self.custom("DROP_CLIENT", None, re.compile)
+        self.description = self.default('DESCRIPTION', '')
+        self.payment_address = self.default('PAYMENT_ADDRESS', '')
+        self.daily_fee = self.integer('DAILY_FEE', 0)
 
         # Identities
         clearnet_identity = self.clearnet_identity()

--- a/torba/torba/server/env.py
+++ b/torba/torba/server/env.py
@@ -81,7 +81,6 @@ class Env:
         self.session_timeout = self.integer('SESSION_TIMEOUT', 600)
         self.drop_client = self.custom("DROP_CLIENT", None, re.compile)
         self.description = self.default('DESCRIPTION', '')
-        self.payment_address = self.default('PAYMENT_ADDRESS', '')
         self.daily_fee = self.integer('DAILY_FEE', 0)
 
         # Identities

--- a/torba/torba/server/session.py
+++ b/torba/torba/server/session.py
@@ -768,7 +768,7 @@ class ElectrumX(SessionBase):
             'protocol_max': max_str,
             'genesis_hash': env.coin.GENESIS_HASH,
             'description': env.description,
-            'payment_address': env.payment_address,
+            'payment_address': env.donation_address,
             'daily_fee': env.daily_fee,
             'hash_function': 'sha256',
         }

--- a/torba/torba/server/session.py
+++ b/torba/torba/server/session.py
@@ -767,6 +767,9 @@ class ElectrumX(SessionBase):
             'protocol_min': min_str,
             'protocol_max': max_str,
             'genesis_hash': env.coin.GENESIS_HASH,
+            'description': env.description,
+            'payment_address': env.payment_address,
+            'daily_fee': env.daily_fee,
             'hash_function': 'sha256',
         }
 


### PR DESCRIPTION
Adds the following new config variables (which currently are environment variables but are subject to change):
`DESCRIPTION` (str): simple server description
`DAILY_FEE` (int): daily fee in dewies

The fee is collected to the existing configuration for donation address, so other electrum protocol clients can understand it. Also, a 0/unset `DAILY_FEE` with a `DONATION_ADDRESS` keeps meaning what wallet operators are used to:
`DONATION_ADDRESS` (str): address for the daily fee/donations

We might reconsider `BANNER_FILE` but throwing up an entire file through `server.features` doesn't seem ok, `DESCRIPTION` should be a short description of the server (like a title, for server lists) and not a full shell-style banner.