### PR TITLE
Fix failing key payment for null max key fee

### DIFF
--- a/lbry/lbry/stream/stream_manager.py
+++ b/lbry/lbry/stream/stream_manager.py
@@ -401,8 +401,8 @@ class StreamManager:
                 ), 5)
                 max_fee_amount = round(exchange_rate_manager.convert_currency(
                     self.config.max_key_fee['currency'], "LBC", Decimal(self.config.max_key_fee['amount'])
-                ), 5)
-                if fee_amount > max_fee_amount:
+                ), 5) if self.config.max_key_fee else None
+                if max_fee_amount and fee_amount > max_fee_amount:
                     msg = f"fee of {fee_amount} exceeds max configured to allow of {max_fee_amount}"
                     log.warning(msg)
                     raise KeyFeeAboveMaxAllowed(msg)

--- a/lbry/tests/unit/stream/test_stream_manager.py
+++ b/lbry/tests/unit/stream/test_stream_manager.py
@@ -76,14 +76,8 @@ def get_mock_wallet(sd_hash, storage, balance=10.0, fee=None):
             claim['permanent_url']: claim
         }
 
-    async def mock_send_amount_to_address(*args):
-        transaction = mock.Mock()
-        transaction.raw = b'raw transaction'
-        return transaction
-
-    mock_wallet = mock.Mock(spec=LbryWalletManager, return_value=asyncio.Future())
+    mock_wallet = mock.Mock(spec=LbryWalletManager)
     mock_wallet.ledger.resolve = mock_resolve
-    mock_wallet.send_amount_to_address = mock_send_amount_to_address
     mock_wallet.ledger.network.client.server = ('fakespv.lbry.com', 50001)
 
     async def get_balance(*_):
@@ -328,22 +322,6 @@ class TestStreamManager(BlobExchangeTestBase):
         }
         await self.setup_stream_manager(1000000.0, fee)
         await self._test_download_error_on_start(KeyFeeAboveMaxAllowed, "")
-
-    async def test_null_max_key_fee(self):
-        fee = {
-            'currency': 'LBC',
-            'amount': 0.001,
-            'address': 'bYFeMtSL7ARuG1iMpjFyrnTe4oJHSAVNXF',
-            'version': '_0_0_1'
-        }
-        self.client_config.max_key_fee = None
-        error = None
-        await self.setup_stream_manager(1000000.0, fee)
-        try:
-            await self.stream_manager.download_stream_from_uri(self.uri, self.exchange_rate_manager)
-        except Exception as err:
-            error = err
-        self.assertIsNone(error)
 
     async def test_resolve_error(self):
         await self.setup_stream_manager()


### PR DESCRIPTION
Addressing #2051. Added a unit test which fails before the fix, and passes after. Also, I verified that paid downloads fail before the fix, download successfully after, and the payment proceeds as expected.