### PR TITLE
Handle claim_name as a string

### DIFF
--- a/lbry/lbry/extras/cli.py
+++ b/lbry/lbry/extras/cli.py
@@ -45,7 +45,7 @@ async def execute_command(conf, method, params, callback=display):
 def normalize_value(x, key=None):
     if not isinstance(x, str):
         return x
-    if key in ('uri', 'channel_name', 'name', 'file_name', 'download_directory'):
+    if key in ('uri', 'channel_name', 'name', 'file_name', 'claim_name', 'download_directory'):
         return x
     if x.lower() == 'true':
         return True

--- a/lbry/tests/unit/test_cli.py
+++ b/lbry/tests/unit/test_cli.py
@@ -51,6 +51,7 @@ class CLITest(AsyncioTestCase):
         self.assertEqual('3', normalize_value('3', key="name"))
         self.assertEqual('3', normalize_value('3', key="download_directory"))
         self.assertEqual('3', normalize_value('3', key="channel_name"))
+        self.assertEqual('3', normalize_value('3', key="claim_name"))
 
         self.assertEqual(3, normalize_value('3', key="some_other_thing"))
 


### PR DESCRIPTION
This is a simple change to address #1832. Currently, when claim name is a digit, e.g. '1234' (docopt automatically converts to string), it is normalized to integer. Since it has been published as a string, the comparison then fails and the claim is not retrievable via either `lbrynet file list --claim_name=1234` or `lbrynet file list --claim_name="1234"` (tested for both).