### PR TITLE
Sanitize file names before saving

### DIFF
--- a/lbry/lbry/extras/daemon/Daemon.py
+++ b/lbry/lbry/extras/daemon/Daemon.py
@@ -2810,7 +2810,7 @@ class Daemon(metaclass=JSONRPCServerType):
 
     @requires(WALLET_COMPONENT, STREAM_MANAGER_COMPONENT, BLOB_COMPONENT, DATABASE_COMPONENT)
     async def jsonrpc_stream_update(
-            self, claim_id, bid=None, file_path=None,
+            self, claim_id, bid=None, file_path=None, file_name=None,
             channel_id=None, channel_name=None, channel_account_id=None, clear_channel=False,
             account_id=None, wallet_id=None, claim_address=None, funding_account_ids=None,
             preview=False, blocking=False, replace=False, **kwargs):
@@ -2979,7 +2979,7 @@ class Daemon(metaclass=JSONRPCServerType):
             claim.stream.update(file_path=file_path, **kwargs)
         else:
             claim = Claim.from_bytes(old_txo.claim.to_bytes())
-            claim.stream.update(file_path=file_path, **kwargs)
+            claim.stream.update(file_path=file_path, file_name=file_name, **kwargs)
         tx = await Transaction.claim_update(
             old_txo, claim, amount, claim_address, funding_accounts, funding_accounts[0], channel
         )
@@ -2988,10 +2988,13 @@ class Daemon(metaclass=JSONRPCServerType):
         stream_hash = None
         if not preview:
             old_stream_hash = await self.storage.get_stream_hash_for_sd_hash(old_txo.claim.stream.source.sd_hash)
-            if file_path is not None:
-                if old_stream_hash:
-                    stream_to_delete = self.stream_manager.get_stream_by_stream_hash(old_stream_hash)
-                    await self.stream_manager.delete_stream(stream_to_delete, delete_file=False)
+            old_stream = self.stream_manager.get_stream_by_stream_hash(old_stream_hash)
+            if not file_path and file_name and old_stream:
+                old_path, _ = os.path.split(old_stream.full_path)
+                file_path = os.path.join(old_path, file_name)
+            if file_path:
+                if old_stream:
+                    await self.stream_manager.delete_stream(old_stream, delete_file=False)
                 file_stream = await self.stream_manager.create_stream(file_path)
                 new_txo.claim.stream.source.sd_hash = file_stream.sd_hash
                 new_txo.script.generate()

--- a/lbry/lbry/stream/descriptor.py
+++ b/lbry/lbry/stream/descriptor.py
@@ -89,7 +89,7 @@ class StreamDescriptor:
         self.blob_dir = blob_dir
         self.stream_name = stream_name
         self.key = key
-        self.suggested_file_name = sanitize_file_name(suggested_file_name)
+        self.suggested_file_name = suggested_file_name
         self.blobs = blobs
         self.stream_hash = stream_hash or self.get_stream_hash()
         self.sd_hash = sd_hash
@@ -251,9 +251,10 @@ class StreamDescriptor:
             blobs.append(blob_info)
         blobs.append(
             BlobInfo(len(blobs), 0, binascii.hexlify(next(iv_generator)).decode()))  # add the stream terminator
+        file_name = os.path.basename(file_path)
+        suggested_file_name = sanitize_file_name(file_name)
         descriptor = cls(
-            loop, blob_dir, os.path.basename(file_path), binascii.hexlify(key).decode(), os.path.basename(file_path),
-            blobs
+            loop, blob_dir, file_name, binascii.hexlify(key).decode(), suggested_file_name, blobs
         )
         sd_blob = await descriptor.make_sd_blob(old_sort=old_sort, blob_completed_callback=blob_completed_callback)
         descriptor.sd_hash = sd_blob.blob_hash

--- a/lbry/lbry/stream/descriptor.py
+++ b/lbry/lbry/stream/descriptor.py
@@ -15,6 +15,17 @@ from lbry.error import InvalidStreamDescriptorError
 
 log = logging.getLogger(__name__)
 
+_exprs = [
+    '[<>:"/\\\|\?\*]+',  # Illegal characters
+    '[\\x00-\\x1F]+',  # All characters in range 0-31
+    '[ \t]*(\.)+[ \t]*$',  # Dots at the end
+    '(^[ \t]+|[ \t]+$)',  # Leading and trailing whitespace
+    '^CON$', '^PRN$', '^AUX$',  # Illegal names
+    '^NUL$', '^COM[1-9]$', '^LPT[1-9]$'
+]
+
+RES = re.compile('(' + '|'.join((expr for expr in _exprs)) + ')')
+
 
 def format_sd_info(stream_name: str, key: str, suggested_file_name: str, stream_hash: str,
                    blobs: typing.List[typing.Dict]) -> typing.Dict:
@@ -48,16 +59,6 @@ def file_reader(file_path: str):
 
 
 def sanitize_file_name(dirty_name: str):
-    exprs = [
-        '[<>:"/\\\|\?\*]+',                         # Illegal characters
-        '[\\x00-\\x1F]+',                           # All characters in range 0-31
-        '[ \t]*(\.)+[ \t]*$',                       # Dots at the end
-        '(^[ \t]+|[ \t]+$)',                        # Leading and trailing whitespace
-        '^CON$', '^PRN$', '^AUX$',                  # Illegal names
-        '^NUL$', '^COM[1-9]$', '^LPT[1-9]$']
-
-    RES = re.compile('(' + '|'.join((expr for expr in exprs)) + ')')
-
     file_name, ext = os.path.splitext(dirty_name)
     file_name = re.sub(RES, '', file_name)
     ext = re.sub(RES, '', ext)

--- a/lbry/lbry/stream/descriptor.py
+++ b/lbry/lbry/stream/descriptor.py
@@ -15,16 +15,16 @@ from lbry.error import InvalidStreamDescriptorError
 
 log = logging.getLogger(__name__)
 
-_exprs = [
-    '[<>:"/\\\|\?\*]+',  # Illegal characters
-    '[\\x00-\\x1F]+',  # All characters in range 0-31
-    '[ \t]*(\.)+[ \t]*$',  # Dots at the end
-    '(^[ \t]+|[ \t]+$)',  # Leading and trailing whitespace
-    '^CON$', '^PRN$', '^AUX$',  # Illegal names
-    '^NUL$', '^COM[1-9]$', '^LPT[1-9]$'
-]
-
-RES = re.compile('(' + '|'.join((expr for expr in _exprs)) + ')')
+RE_ILLEGAL_FILENAME_CHARS = re.compile(
+    '('
+    '[<>:"/\\\|\?\*]+|'               # Illegal characters
+    '[\\x00-\\x1F]+|'                 # All characters in range 0-31
+    '[ \t]*(\.)+[ \t]*$|'             # Dots at the end
+    '(^[ \t]+|[ \t]+$)|'              # Leading and trailing whitespace
+    '^CON$|^PRN$|^AUX$|'              # Illegal names
+    '^NUL$|^COM[1-9]$|^LPT[1-9]$'     # ...
+    ')'
+)
 
 
 def format_sd_info(stream_name: str, key: str, suggested_file_name: str, stream_hash: str,
@@ -60,8 +60,8 @@ def file_reader(file_path: str):
 
 def sanitize_file_name(dirty_name: str):
     file_name, ext = os.path.splitext(dirty_name)
-    file_name = re.sub(RES, '', file_name)
-    ext = re.sub(RES, '', ext)
+    file_name = re.sub(RE_ILLEGAL_FILENAME_CHARS, '', file_name)
+    ext = re.sub(RE_ILLEGAL_FILENAME_CHARS, '', ext)
 
     if not file_name:
         log.warning('Unable to suggest a file name for %s', dirty_name)

--- a/lbry/lbry/stream/descriptor.py
+++ b/lbry/lbry/stream/descriptor.py
@@ -58,14 +58,15 @@ def file_reader(file_path: str):
             offset += bytes_to_read
 
 
-def sanitize_file_name(dirty_name: str):
+def sanitize_file_name(dirty_name: str, default_file_name: str = 'lbry_download'):
     file_name, ext = os.path.splitext(dirty_name)
     file_name = re.sub(RE_ILLEGAL_FILENAME_CHARS, '', file_name)
     ext = re.sub(RE_ILLEGAL_FILENAME_CHARS, '', ext)
 
     if not file_name:
-        log.warning('Unable to suggest a file name for %s', dirty_name)
-    elif len(ext) > 1:
+        log.warning('Unable to sanitize file name for %s, returning default value %s', dirty_name, default_file_name)
+        file_name = default_file_name
+    if len(ext) > 1:
         file_name += ext
 
     return file_name

--- a/lbry/lbry/stream/managed_stream.py
+++ b/lbry/lbry/stream/managed_stream.py
@@ -3,7 +3,6 @@ import asyncio
 import typing
 import logging
 import binascii
-import re
 from aiohttp.web import Request, StreamResponse, HTTPRequestRangeNotSatisfiable
 from lbry.utils import generate_id
 from lbry.error import DownloadSDTimeout
@@ -38,11 +37,6 @@ def _get_next_available_file_name(download_directory: str, file_name: str) -> st
 
 async def get_next_available_file_name(loop: asyncio.AbstractEventLoop, download_directory: str, file_name: str) -> str:
     return await loop.run_in_executor(None, _get_next_available_file_name, download_directory, file_name)
-
-
-def sanitize_file_name(file_name):
-    file_name = str(file_name).strip().replace(' ', '_')
-    return re.sub(r'(?u)[^-\w.]', '', file_name)
 
 
 class ManagedStream:
@@ -121,12 +115,7 @@ class ManagedStream:
 
     @property
     def file_name(self) -> typing.Optional[str]:
-        return self._file_name or \
-            (sanitize_file_name(self.descriptor.suggested_file_name) if self.descriptor else None)
-
-    @file_name.setter
-    def file_name(self, value):
-        self._file_name = sanitize_file_name(value)
+        return self._file_name or (self.descriptor.suggested_file_name if self.descriptor else None)
 
     @property
     def status(self) -> str:
@@ -261,7 +250,7 @@ class ManagedStream:
         self.delayed_stop_task = self.loop.create_task(self._delayed_stop())
         if not await self.blob_manager.storage.file_exists(self.sd_hash):
             if save_now:
-                file_name, download_dir = self.file_name, self.download_directory
+                file_name, download_dir = self._file_name, self.download_directory
             else:
                 file_name, download_dir = None, None
             self.rowid = await self.blob_manager.storage.save_downloaded_file(
@@ -371,7 +360,7 @@ class ManagedStream:
                 await self.blob_manager.storage.change_file_download_dir_and_file_name(
                     self.stream_hash, None, None
                 )
-                self.file_name, self.download_directory = None, None
+                self._file_name, self.download_directory = None, None
                 await self.blob_manager.storage.clear_saved_file(self.stream_hash)
                 await self.update_status(self.STATUS_STOPPED)
                 return
@@ -390,14 +379,14 @@ class ManagedStream:
         self.download_directory = download_directory or self.download_directory or self.config.download_dir
         if not self.download_directory:
             raise ValueError("no directory to download to")
-        if not (file_name or self.file_name):
+        if not (file_name or self._file_name or self.descriptor.suggested_file_name):
             raise ValueError("no file name to download to")
         if not os.path.isdir(self.download_directory):
             log.warning("download directory '%s' does not exist, attempting to make it", self.download_directory)
             os.mkdir(self.download_directory)
-        self.file_name = await get_next_available_file_name(
+        self._file_name = await get_next_available_file_name(
             self.loop, self.download_directory,
-            file_name or self.descriptor.suggested_file_name
+            file_name or self.file_name
         )
         await self.blob_manager.storage.change_file_download_dir_and_file_name(
             self.stream_hash, self.download_directory, self.file_name

--- a/lbry/lbry/stream/managed_stream.py
+++ b/lbry/lbry/stream/managed_stream.py
@@ -8,7 +8,7 @@ from lbry.utils import generate_id
 from lbry.error import DownloadSDTimeout
 from lbry.schema.mime_types import guess_media_type
 from lbry.stream.downloader import StreamDownloader
-from lbry.stream.descriptor import StreamDescriptor
+from lbry.stream.descriptor import StreamDescriptor, sanitize_file_name
 from lbry.stream.reflector.client import StreamReflectorClient
 from lbry.extras.daemon.storage import StoredStreamClaim
 from lbry.blob import MAX_BLOB_SIZE
@@ -386,7 +386,7 @@ class ManagedStream:
             os.mkdir(self.download_directory)
         self._file_name = await get_next_available_file_name(
             self.loop, self.download_directory,
-            file_name or self.file_name
+            file_name or self._file_name or sanitize_file_name(self.descriptor.suggested_file_name)
         )
         await self.blob_manager.storage.change_file_download_dir_and_file_name(
             self.stream_hash, self.download_directory, self.file_name

--- a/lbry/lbry/testcase.py
+++ b/lbry/lbry/testcase.py
@@ -197,9 +197,9 @@ class CommandTestCase(IntegrationTestCase):
         """ Synchronous version of `out` method. """
         return json.loads(jsonrpc_dumps_pretty(value, ledger=self.ledger))['result']
 
-    def create_tempfile(self, data=None, prefix=None, suffix=None, dir=None):
-        dir = dir or self.daemon.conf.download_dir
-        file = tempfile.NamedTemporaryFile(prefix=prefix, suffix=suffix, dir=dir)
+    def create_tempfile(self, data=None, prefix=None, suffix=None, dir_path=None):
+        dir_path = dir_path or self.daemon.conf.download_dir
+        file = tempfile.NamedTemporaryFile(prefix=prefix, suffix=suffix, dir=dir_path)
         file.write(data)
         file.flush()
 

--- a/lbry/lbry/testcase.py
+++ b/lbry/lbry/testcase.py
@@ -199,18 +199,10 @@ class CommandTestCase(IntegrationTestCase):
 
     def create_tempfile(self, data=None, prefix=None, suffix=None, dir_path=None):
         dir_path = dir_path or self.daemon.conf.download_dir
-        file = tempfile.NamedTemporaryFile(prefix=prefix, suffix=suffix, dir=dir_path)
-        file.write(data)
-        file.flush()
-
-        def cleanup():
-            try:
-                file.close()
-            except FileNotFoundError:
-                pass
-
-        self.addCleanup(cleanup)
-        return file.name
+        self.file = tempfile.NamedTemporaryFile(prefix=prefix, suffix=suffix, dir=dir_path)
+        self.file.write(data)
+        self.file.flush()
+        return self.file.name
 
     async def stream_create(self, name='hovercraft', bid='1.0', data=b'hi!', confirm=True,
                             prefix=None, suffix=None, **kwargs):

--- a/lbry/lbry/testcase.py
+++ b/lbry/lbry/testcase.py
@@ -197,20 +197,11 @@ class CommandTestCase(IntegrationTestCase):
         """ Synchronous version of `out` method. """
         return json.loads(jsonrpc_dumps_pretty(value, ledger=self.ledger))['result']
 
-    def create_tempfile(self, data=None, prefix=None, suffix=None, dir_path=None):
-        dir_path = dir_path or self.daemon.conf.download_dir
-        file = tempfile.NamedTemporaryFile(prefix=prefix, suffix=suffix, dir=dir_path)
-        file.write(data)
-        file.flush()
-
-        def cleanup():
-            try:
-                file.close()
-            except FileNotFoundError:
-                pass
-
-        self.addCleanup(cleanup)
-        return file.name
+    def create_tempfile(self, data=None, prefix=None, suffix=None):
+        self._file = tempfile.NamedTemporaryFile(prefix=prefix, suffix=suffix)
+        self._file.write(data)
+        self._file.flush()
+        return self._file.name
 
     async def stream_create(self, name='hovercraft', bid='1.0', data=b'hi!', confirm=True,
                             prefix=None, suffix=None, **kwargs):

--- a/lbry/lbry/testcase.py
+++ b/lbry/lbry/testcase.py
@@ -199,10 +199,18 @@ class CommandTestCase(IntegrationTestCase):
 
     def create_tempfile(self, data=None, prefix=None, suffix=None, dir_path=None):
         dir_path = dir_path or self.daemon.conf.download_dir
-        self.file = tempfile.NamedTemporaryFile(prefix=prefix, suffix=suffix, dir=dir_path)
-        self.file.write(data)
-        self.file.flush()
-        return self.file.name
+        file = tempfile.NamedTemporaryFile(prefix=prefix, suffix=suffix, dir=dir_path)
+        file.write(data)
+        file.flush()
+
+        def cleanup():
+            try:
+                file.close()
+            except FileNotFoundError:
+                pass
+
+        self.addCleanup(cleanup)
+        return file.name
 
     async def stream_create(self, name='hovercraft', bid='1.0', data=b'hi!', confirm=True,
                             prefix=None, suffix=None, **kwargs):

--- a/lbry/lbry/testcase.py
+++ b/lbry/lbry/testcase.py
@@ -198,10 +198,19 @@ class CommandTestCase(IntegrationTestCase):
         return json.loads(jsonrpc_dumps_pretty(value, ledger=self.ledger))['result']
 
     def create_tempfile(self, data=None, prefix=None, suffix=None):
-        self._file = tempfile.NamedTemporaryFile(prefix=prefix, suffix=suffix)
-        self._file.write(data)
-        self._file.flush()
-        return self._file.name
+        file = tempfile.NamedTemporaryFile(prefix=prefix, suffix=suffix)
+
+        # tempfile throws FileNotFoundError when file is deleted before it's closed
+        def cleanup():
+            try:
+                file.close()
+            except FileNotFoundError:
+                pass
+
+        self.addCleanup(cleanup)
+        file.write(data)
+        file.flush()
+        return file.name
 
     async def stream_create(self, name='hovercraft', bid='1.0', data=b'hi!', confirm=True,
                             prefix=None, suffix=None, **kwargs):

--- a/lbry/lbry/testcase.py
+++ b/lbry/lbry/testcase.py
@@ -197,8 +197,9 @@ class CommandTestCase(IntegrationTestCase):
         """ Synchronous version of `out` method. """
         return json.loads(jsonrpc_dumps_pretty(value, ledger=self.ledger))['result']
 
-    async def stream_create(self, name='hovercraft', bid='1.0', data=b'hi!', confirm=True, **kwargs):
-        file = tempfile.NamedTemporaryFile()
+    async def stream_create(self, name='hovercraft', bid='1.0', data=b'hi!', confirm=True,
+                            prefix=None, suffix=None, **kwargs):
+        file = tempfile.NamedTemporaryFile(prefix=prefix, suffix=suffix)
 
         def cleanup():
             try:

--- a/lbry/tests/integration/test_file_commands.py
+++ b/lbry/tests/integration/test_file_commands.py
@@ -103,8 +103,8 @@ class FileCommands(CommandTestCase):
         # Update the stream and assert the file name is not sanitized, but the suggested file name is
         prefix, suffix = 'derpyderp?', '.ext.'
         san_prefix, san_suffix = 'derpyderp', '.ext'
-        new_file_name = os.path.basename(self.create_tempfile(data=b'amazing content', prefix=prefix, suffix=suffix))
-        tx = await self.stream_update(claim_id, file_name=new_file_name)
+        new_file_path = self.create_tempfile(data=b'amazing content', prefix=prefix, suffix=suffix)
+        tx = await self.stream_update(claim_id, file_path=new_file_path)
         full_path = (await self.daemon.jsonrpc_get('lbry://' + claim_name, save_file=True)).full_path
         updated_stream = self.daemon.jsonrpc_file_list()[0]
 

--- a/lbry/tests/integration/test_file_commands.py
+++ b/lbry/tests/integration/test_file_commands.py
@@ -51,11 +51,11 @@ class FileCommands(CommandTestCase):
         suffix = '.ext.'
         san_prefix = 'antz m'
         san_suffix = '.ext'
-        claim = await self.stream_create('foo', '0.01', prefix=prefix, suffix=suffix)
+        tx = await self.stream_create('foo', '0.01', prefix=prefix, suffix=suffix)
         stream = self.daemon.jsonrpc_file_list()[0]
 
-        # Check that file list and source contains the local unsanitized name, but suggested name is sanitized
-        source_file_name = claim['outputs'][0]['value']['source']['name']
+        # Assert that file list and source contains the local unsanitized name, but suggested name is sanitized
+        source_file_name = tx['outputs'][0]['value']['source']['name']
         file_list_name = stream.file_name
         suggested_file_name = stream.descriptor.suggested_file_name
         self.assertTrue(source_file_name.startswith(prefix))
@@ -64,15 +64,16 @@ class FileCommands(CommandTestCase):
         self.assertTrue(suggested_file_name.startswith(san_prefix))
         self.assertTrue(suggested_file_name.endswith(san_suffix))
 
-        # Delete the file, re-download and check that the file name is sanitized
+        # Delete the file, re-download and assert that the file name is sanitized
         self.assertTrue(await self.daemon.jsonrpc_file_delete(claim_name='foo'))
+        self.assertEqual(len(self.daemon.jsonrpc_file_list()), 0)
         full_path = (await self.daemon.jsonrpc_get('lbry://foo', save_file=True)).full_path
         file_name = os.path.basename(full_path)
         self.assertTrue(os.path.isfile(full_path))
         self.assertTrue(file_name.startswith(san_prefix))
         self.assertTrue(file_name.endswith(san_suffix))
 
-        # Check that the downloaded file name is not sanitized when user provides custom file name
+        # Assert that the downloaded file name is not sanitized when user provides custom file name
         self.assertTrue(await self.daemon.jsonrpc_file_delete(claim_name='foo'))
         file_name = 'my <u?|*m.name'
         full_path = (await self.daemon.jsonrpc_get('lbry://foo', file_name=file_name, save_file=True)).full_path

--- a/lbry/tests/integration/test_file_commands.py
+++ b/lbry/tests/integration/test_file_commands.py
@@ -45,6 +45,40 @@ class FileCommands(CommandTestCase):
             {stream.sd_hash, stream.descriptor.blobs[0].blob_hash}
         )
 
+    async def test_publish_with_illegal_chars(self):
+        # Stream a file with file name containing invalid chars
+        prefix = '?an|t:z< m<'
+        suffix = '.ext.'
+        san_prefix = 'antz m'
+        san_suffix = '.ext'
+        claim = await self.stream_create('foo', '0.01', prefix=prefix, suffix=suffix)
+        stream = self.daemon.jsonrpc_file_list()[0]
+
+        # Check that file list and source contains the local unsanitized name, but suggested name is sanitized
+        source_file_name = claim['outputs'][0]['value']['source']['name']
+        file_list_name = stream.file_name
+        suggested_file_name = stream.descriptor.suggested_file_name
+        self.assertTrue(source_file_name.startswith(prefix))
+        self.assertTrue(source_file_name.endswith(suffix))
+        self.assertEqual(file_list_name, source_file_name)
+        self.assertTrue(suggested_file_name.startswith(san_prefix))
+        self.assertTrue(suggested_file_name.endswith(san_suffix))
+
+        # Delete the file, re-download and check that the file name is sanitized
+        self.assertTrue(await self.daemon.jsonrpc_file_delete(claim_name='foo'))
+        full_path = (await self.daemon.jsonrpc_get('lbry://foo', save_file=True)).full_path
+        file_name = os.path.basename(full_path)
+        self.assertTrue(os.path.isfile(full_path))
+        self.assertTrue(file_name.startswith(san_prefix))
+        self.assertTrue(file_name.endswith(san_suffix))
+
+        # Check that the downloaded file name is not sanitized when user provides custom file name
+        self.assertTrue(await self.daemon.jsonrpc_file_delete(claim_name='foo'))
+        file_name = 'my <u?|*m.name'
+        full_path = (await self.daemon.jsonrpc_get('lbry://foo', file_name=file_name, save_file=True)).full_path
+        self.assertTrue(os.path.isfile(full_path))
+        self.assertEqual(file_name, os.path.basename(full_path))
+
     async def test_file_list_fields(self):
         await self.stream_create('foo', '0.01')
         file_list = self.sout(self.daemon.jsonrpc_file_list())

--- a/lbry/tests/unit/stream/test_managed_stream.py
+++ b/lbry/tests/unit/stream/test_managed_stream.py
@@ -46,7 +46,7 @@ class TestManagedStream(BlobExchangeTestBase):
         self.stream = ManagedStream(
             self.loop, self.client_config, self.client_blob_manager, self.sd_hash, self.client_dir
         )
-        await self._test_transfer_stream(1, skip_setup=True)
+        await self._test_transfer_stream(10, skip_setup=True)
         self.assertTrue(self.stream.completed)
         self.assertEqual(self.stream.file_name, 'tt_f')
         self.assertTrue(self.stream.output_file_exists)

--- a/lbry/tests/unit/stream/test_managed_stream.py
+++ b/lbry/tests/unit/stream/test_managed_stream.py
@@ -39,6 +39,14 @@ class TestManagedStream(BlobExchangeTestBase):
             self.loop, self.client_config, self.client_blob_manager, self.sd_hash, self.client_dir
         )
 
+    async def test_file_saves_with_valid_file_name(self):
+        await self._test_transfer_stream(10, file_name="Bitcoin can't be shut down or regulated?.mov")
+        self.assertTrue(self.stream.output_file_exists)
+        self.assertTrue(self.stream.completed)
+        self.assertEqual(self.stream.file_name, "Bitcoin_cant_be_shut_down_or_regulated.mov")
+        self.assertEqual(self.stream.full_path, os.path.join(self.stream.download_directory, self.stream.file_name))
+        self.assertTrue(os.path.isfile(self.stream.full_path))
+
     async def test_status_file_completed(self):
         await self._test_transfer_stream(10)
         self.assertTrue(self.stream.output_file_exists)
@@ -48,7 +56,8 @@ class TestManagedStream(BlobExchangeTestBase):
         self.assertTrue(self.stream.output_file_exists)
         self.assertFalse(self.stream.completed)
 
-    async def _test_transfer_stream(self, blob_count: int, mock_accumulate_peers=None, stop_when_done=True):
+    async def _test_transfer_stream(self, blob_count: int, mock_accumulate_peers=None, stop_when_done=True,
+                                    file_name=None):
         await self.setup_stream(blob_count)
         mock_node = mock.Mock(spec=Node)
 
@@ -59,7 +68,7 @@ class TestManagedStream(BlobExchangeTestBase):
             return q2, self.loop.create_task(_task())
 
         mock_node.accumulate_peers = mock_accumulate_peers or _mock_accumulate_peers
-        await self.stream.save_file(node=mock_node)
+        await self.stream.save_file(node=mock_node, file_name=file_name)
         await self.stream.finished_write_attempt.wait()
         self.assertTrue(os.path.isfile(self.stream.full_path))
         if stop_when_done:

--- a/lbry/tests/unit/stream/test_stream_descriptor.py
+++ b/lbry/tests/unit/stream/test_stream_descriptor.py
@@ -79,8 +79,8 @@ class TestStreamDescriptor(AsyncioTestCase):
         await self._test_invalid_sd()
 
     async def test_sanitize_file_name(self):
-        test_cases = [' t/-?t|.g.ext ', 'end_me .', '', '.file', 'test name.ext', 'COM8', 'LPT2']
-        expected = ['t-t.g.ext', 'end_me', '', '.file', 'test name.ext', '', '']
+        test_cases = [' t/-?t|.g.ext ', 'end_dot .', '.file\0\0', 'test n\16ame.ext', 'COM8', 'LPT2', '']
+        expected = ['t-t.g.ext', 'end_dot', '.file', 'test name.ext', '', '', '']
         actual = [sanitize_file_name(tc) for tc in test_cases]
         self.assertListEqual(actual, expected)
 

--- a/lbry/tests/unit/stream/test_stream_descriptor.py
+++ b/lbry/tests/unit/stream/test_stream_descriptor.py
@@ -79,10 +79,14 @@ class TestStreamDescriptor(AsyncioTestCase):
         await self._test_invalid_sd()
 
     def test_sanitize_file_name(self):
-        test_cases = [' t/-?t|.g.ext ', 'end_dot .', '.file\0\0', 'test n\16ame.ext', 'COM8', 'LPT2', '']
-        expected = ['t-t.g.ext', 'end_dot', '.file', 'test name.ext', '', '', '']
-        actual = [sanitize_file_name(tc) for tc in test_cases]
-        self.assertListEqual(actual, expected)
+        self.assertEqual(sanitize_file_name(' t/-?t|.g.ext '), 't-t.g.ext')
+        self.assertEqual(sanitize_file_name('end_dot .'), 'end_dot')
+        self.assertEqual(sanitize_file_name('.file\0\0'), '.file')
+        self.assertEqual(sanitize_file_name('test n\16ame.ext'), 'test name.ext')
+        self.assertEqual(sanitize_file_name('COM8'), '')
+        self.assertEqual(sanitize_file_name('LPT2'), '')
+        self.assertEqual(sanitize_file_name(''), '')
+
 
 class TestRecoverOldStreamDescriptors(AsyncioTestCase):
     async def test_old_key_sort_sd_blob(self):

--- a/lbry/tests/unit/stream/test_stream_descriptor.py
+++ b/lbry/tests/unit/stream/test_stream_descriptor.py
@@ -10,7 +10,7 @@ from lbry.conf import Config
 from lbry.error import InvalidStreamDescriptorError
 from lbry.extras.daemon.storage import SQLiteStorage
 from lbry.blob.blob_manager import BlobManager
-from lbry.stream.descriptor import StreamDescriptor
+from lbry.stream.descriptor import StreamDescriptor, sanitize_file_name
 
 
 class TestStreamDescriptor(AsyncioTestCase):
@@ -78,6 +78,11 @@ class TestStreamDescriptor(AsyncioTestCase):
         self.sd_dict['blobs'][-2]['length'] = 0
         await self._test_invalid_sd()
 
+    async def test_sanitize_file_name(self):
+        test_cases = [' t/-?t|.g.ext ', 'end_me .', '', '.file', 'test name.ext', 'COM8', 'LPT2']
+        expected = ['t-t.g.ext', 'end_me', '', '.file', 'test name.ext', '', '']
+        actual = [sanitize_file_name(tc) for tc in test_cases]
+        self.assertListEqual(actual, expected)
 
 class TestRecoverOldStreamDescriptors(AsyncioTestCase):
     async def test_old_key_sort_sd_blob(self):

--- a/lbry/tests/unit/stream/test_stream_descriptor.py
+++ b/lbry/tests/unit/stream/test_stream_descriptor.py
@@ -83,9 +83,9 @@ class TestStreamDescriptor(AsyncioTestCase):
         self.assertEqual(sanitize_file_name('end_dot .'), 'end_dot')
         self.assertEqual(sanitize_file_name('.file\0\0'), '.file')
         self.assertEqual(sanitize_file_name('test n\16ame.ext'), 'test name.ext')
-        self.assertEqual(sanitize_file_name('COM8'), '')
-        self.assertEqual(sanitize_file_name('LPT2'), '')
-        self.assertEqual(sanitize_file_name(''), '')
+        self.assertEqual(sanitize_file_name('COM8.ext', default_file_name='default1'), 'default1.ext')
+        self.assertEqual(sanitize_file_name('LPT2', default_file_name='default2'), 'default2')
+        self.assertEqual(sanitize_file_name('', default_file_name=''), '')
 
 
 class TestRecoverOldStreamDescriptors(AsyncioTestCase):

--- a/lbry/tests/unit/stream/test_stream_descriptor.py
+++ b/lbry/tests/unit/stream/test_stream_descriptor.py
@@ -78,7 +78,7 @@ class TestStreamDescriptor(AsyncioTestCase):
         self.sd_dict['blobs'][-2]['length'] = 0
         await self._test_invalid_sd()
 
-    async def test_sanitize_file_name(self):
+    def test_sanitize_file_name(self):
         test_cases = [' t/-?t|.g.ext ', 'end_dot .', '.file\0\0', 'test n\16ame.ext', 'COM8', 'LPT2', '']
         expected = ['t-t.g.ext', 'end_dot', '.file', 'test name.ext', '', '', '']
         actual = [sanitize_file_name(tc) for tc in test_cases]


### PR DESCRIPTION
This PR is to address #2084. I added a setter to `StreamManager.file_name` property which sanitizes it the input value. Getter sanitizes `suggested_file_name` if necessary. The sanitization strips trailing whitespaces, replaces spaces with underscores and removes all non-alphanumeric characters except for dashes and dots. I added a unit test and will add an integration test if you agree with this approach.