### PR TITLE
Make `--verbose` param behave as per documentation

### DIFF
--- a/lbry/lbry/extras/cli.py
+++ b/lbry/lbry/extras/cli.py
@@ -242,11 +242,14 @@ def run_daemon(args: list, conf: Config):
 
     loop = asyncio.get_event_loop()
 
-    log.setLevel(logging.DEBUG if args.verbose == [] else logging.INFO)
-    for module in args.verbose or []:
-        logging.getLogger(module).setLevel(logging.DEBUG)
-    if isinstance(args.verbose, list):
+    log.setLevel(logging.INFO)
+    if args.verbose is not None:
         loop.set_debug(True)
+        if len(args.verbose) > 0:
+            for module in args.verbose:
+                logging.getLogger(module).setLevel(logging.DEBUG)
+        else:
+            log.setLevel(logging.DEBUG)
 
     if conf.share_usage_data:
         loggly_handler = get_loggly_handler()

--- a/lbry/lbry/extras/cli.py
+++ b/lbry/lbry/extras/cli.py
@@ -189,7 +189,7 @@ def get_argument_parser():
     )
     start.add_argument(
         '--verbose', nargs="*",
-        help=('Enable debug output. Optionally specify loggers for which debug output '
+        help=('Enable debug output for lbry logger and event loop. Optionally specify loggers for which debug output '
               'should selectively be applied.')
     )
     Config.contribute_to_argparse(start)
@@ -242,11 +242,11 @@ def run_daemon(args: list, conf: Config):
 
     loop = asyncio.get_event_loop()
 
-    if args.verbose:
-        log.setLevel(logging.DEBUG)
+    log.setLevel(logging.DEBUG if args.verbose == [] else logging.INFO)
+    for module in args.verbose or []:
+        logging.getLogger(module).setLevel(logging.DEBUG)
+    if isinstance(args.verbose, list):
         loop.set_debug(True)
-    else:
-        log.setLevel(logging.INFO)
 
     if conf.share_usage_data:
         loggly_handler = get_loggly_handler()

--- a/lbry/lbry/extras/cli.py
+++ b/lbry/lbry/extras/cli.py
@@ -221,7 +221,7 @@ def ensure_directory_exists(path: str):
         pathlib.Path(path).mkdir(parents=True, exist_ok=True)
 
 
-def run_daemon(args: list, conf: Config):
+def setup_logging(args: argparse.Namespace, conf: Config, loop: asyncio.AbstractEventLoop):
     default_formatter = logging.Formatter("%(asctime)s %(levelname)-8s %(name)s:%(lineno)d: %(message)s")
     file_handler = logging.handlers.RotatingFileHandler(
         conf.log_file_path, maxBytes=2097152, backupCount=5
@@ -240,8 +240,6 @@ def run_daemon(args: list, conf: Config):
     logging.getLogger('aioupnp').setLevel(logging.WARNING)
     logging.getLogger('aiohttp').setLevel(logging.CRITICAL)
 
-    loop = asyncio.get_event_loop()
-
     log.setLevel(logging.INFO)
     if args.verbose is not None:
         loop.set_debug(True)
@@ -256,6 +254,10 @@ def run_daemon(args: list, conf: Config):
         loggly_handler.setLevel(logging.ERROR)
         log.addHandler(loggly_handler)
 
+
+def run_daemon(args: argparse.Namespace, conf: Config):
+    loop = asyncio.get_event_loop()
+    setup_logging(args, conf, loop)
     daemon = Daemon(conf)
 
     def __exit():

--- a/lbry/tests/integration/test_cli.py
+++ b/lbry/tests/integration/test_cli.py
@@ -1,4 +1,6 @@
 import contextlib
+import asyncio
+import logging
 from io import StringIO
 from torba.testcase import AsyncioTestCase
 
@@ -37,3 +39,27 @@ class CLIIntegrationTest(AsyncioTestCase):
             cli.main(["--api", "localhost:5299", "status"])
         actual_output = actual_output.getvalue()
         self.assertIn("connection_status", actual_output)
+
+    def test_setup_logging(self):
+        def setup(argv):
+            parser = cli.get_argument_parser()
+            args, command_args = parser.parse_known_args(argv)
+            loop = asyncio.get_event_loop()
+            conf = Config.create_from_arguments(args)
+            cli.setup_logging(args, conf, loop)
+
+        setup(["start"])
+        self.assertTrue(logging.getLogger("lbry").isEnabledFor(logging.INFO))
+        self.assertFalse(logging.getLogger("lbry").isEnabledFor(logging.DEBUG))
+
+        setup(["start", "--verbose"])
+        self.assertTrue(logging.getLogger("lbry").isEnabledFor(logging.DEBUG))
+        self.assertTrue(logging.getLogger("lbry").isEnabledFor(logging.INFO))
+        self.assertFalse(logging.getLogger("torba").isEnabledFor(logging.DEBUG))
+
+        setup(["start", "--verbose", "lbry.extras", "lbry.wallet", "torba.client"])
+        self.assertTrue(logging.getLogger("lbry.extras").isEnabledFor(logging.DEBUG))
+        self.assertTrue(logging.getLogger("lbry.wallet").isEnabledFor(logging.DEBUG))
+        self.assertTrue(logging.getLogger("torba.client").isEnabledFor(logging.DEBUG))
+        self.assertFalse(logging.getLogger("lbry").isEnabledFor(logging.DEBUG))
+        self.assertFalse(logging.getLogger("torba").isEnabledFor(logging.DEBUG))


### PR DESCRIPTION
Addressing #1739, this PR makes the `--verbose` param behave as per documentation: when it is specified as flag, i.e.  `--verbose`,  debug level is set for `lbry` logger as default, and when a list of strings is passed, debug level is set to each as a logger. This does not check that the loggers are valid modules. 