### PR TITLE
handle intermediate state on wallet client sessions

### DIFF
--- a/torba/tests/client_tests/integration/test_network.py
+++ b/torba/tests/client_tests/integration/test_network.py
@@ -115,6 +115,13 @@ class ReconnectTests(IntegrationTestCase):
         await self.ledger.network.on_connected.first
         self.assertTrue(self.ledger.network.is_connected)
 
+    async def test_online_but_still_unavailable(self):
+        # Edge case. See issue #2445 for context
+        self.assertIsNotNone(self.ledger.network.session_pool.fastest_session)
+        for session in self.ledger.network.session_pool.sessions:
+            session.response_time = None
+        self.assertIsNone(self.ledger.network.session_pool.fastest_session)
+
 
 class ServerPickingTestCase(AsyncioTestCase):
 

--- a/torba/torba/client/basenetwork.py
+++ b/torba/torba/client/basenetwork.py
@@ -185,6 +185,9 @@ class BaseNetwork:
     async def start(self):
         self.running = True
         self._switch_task = asyncio.ensure_future(self.switch_forever())
+        # this may become unnecessary when there are no more bugs found,
+        # but for now it helps understanding log reports
+        self._switch_task.add_done_callback(lambda _: log.info("Wallet client switching task stopped."))
         self.session_pool.start(self.config['default_servers'])
         self.on_header.listen(self._update_remote_height)
 
@@ -284,7 +287,7 @@ class SessionPool:
             return None
         return min(
             [((session.response_time + session.connection_latency) * (session.pending_amount + 1), session)
-             for session in self.available_sessions],
+             for session in self.available_sessions] or [(0, None)],
             key=itemgetter(0)
         )[1]
 


### PR DESCRIPTION
A previously unexpected state could occur where we are online but the sessions aren't available (connection is starting or was lost very recently and is about to be closed). During this state we would ask for a fastest connection but it would hit an empty list and throw an error, which isn't being logged. The logging issue will be handled separately.
This PR also adds a new `INFO` log message for when the wallet server switching task exits with `Wallet client switching task stopped.`. That may be removed in future versions but for now it helps knowing whenever we hit this scenario as this task should live until the daemon stops.