### PR TITLE
normalize tag names (remove duplicates, blank spaces and illegal chars)

### DIFF
--- a/lbry/lbry/schema/attrs.py
+++ b/lbry/lbry/schema/attrs.py
@@ -544,7 +544,3 @@ class TagList(BaseMessageList[str]):
         tag = normalize_tag(tag)
         if tag and tag not in self.message:
             self.message.append(tag)
-
-    def extend(self, tags: List[str]):
-        for tag in tags:
-            self.append(tag)

--- a/lbry/lbry/schema/attrs.py
+++ b/lbry/lbry/schema/attrs.py
@@ -540,17 +540,11 @@ class TagList(BaseMessageList[str]):
     __slots__ = ()
     item_class = str
 
-    @classmethod
-    def create_normalized(cls, message):
-        message[:] = clean_tags(message)
-        return cls(message)
-
     def append(self, tag: str):
         tag = normalize_tag(tag)
-        if tag not in self._message:
-            self._message.append(tag)
+        if tag and tag not in self.message:
+            self.message.append(tag)
 
     def extend(self, tags: List[str]):
-        tags = clean_tags(tags)
-        tags = list(set(tags).difference(set(self._message)))
-        self._message.extend(tags)
+        for tag in tags:
+            self.append(tag)

--- a/lbry/lbry/schema/attrs.py
+++ b/lbry/lbry/schema/attrs.py
@@ -540,16 +540,17 @@ class TagList(BaseMessageList[str]):
     __slots__ = ()
     item_class = str
 
-    def __init__(self, message):
+    @classmethod
+    def create_normalized(cls, message):
         message[:] = clean_tags(message)
-        self.message = message
+        return cls(message)
 
     def append(self, tag: str):
         tag = normalize_tag(tag)
-        if tag not in self.message:
-            self.message.append(tag)
+        if tag not in self._message:
+            self._message.append(tag)
 
     def extend(self, tags: List[str]):
         tags = clean_tags(tags)
-        tags = list(set(tags).difference(set(self.message)))
-        self.message.extend(tags)
+        tags = list(set(tags).difference(set(self._message)))
+        self._message.extend(tags)

--- a/lbry/lbry/schema/attrs.py
+++ b/lbry/lbry/schema/attrs.py
@@ -13,6 +13,7 @@ from torba.client.constants import COIN
 
 from lbry.schema.mime_types import guess_media_type
 from lbry.schema.base import Metadata, BaseMessageList
+from lbry.schema.tags import clean_tags, normalize_tag
 from lbry.schema.types.v2.claim_pb2 import (
     Fee as FeeMessage,
     Location as LocationMessage,
@@ -533,3 +534,22 @@ class LocationList(BaseMessageList[Location]):
 
     def append(self, value):
         self.add().from_value(value)
+
+
+class TagList(BaseMessageList[str]):
+    __slots__ = ()
+    item_class = str
+
+    def __init__(self, message):
+        message[:] = clean_tags(message)
+        self.message = message
+
+    def append(self, tag: str):
+        tag = normalize_tag(tag)
+        if tag not in self.message:
+            self.message.append(tag)
+
+    def extend(self, tags: List[str]):
+        tags = clean_tags(tags)
+        tags = list(set(tags).difference(set(self.message)))
+        self.message.extend(tags)

--- a/lbry/lbry/schema/base.py
+++ b/lbry/lbry/schema/base.py
@@ -120,5 +120,5 @@ class BaseMessageList(Metadata, Generic[I]):
     def __delitem__(self, key):
         del self._message[key]
 
-    def __eq__(self, values: List[str]) -> bool:
-        return self._message == values
+    def __eq__(self, other) -> bool:
+        return self._message == other

--- a/lbry/lbry/schema/base.py
+++ b/lbry/lbry/schema/base.py
@@ -119,3 +119,6 @@ class BaseMessageList(Metadata, Generic[I]):
 
     def __delitem__(self, key):
         del self._message[key]
+
+    def __eq__(self, values: List[str]) -> bool:
+        return self._message == values

--- a/lbry/lbry/schema/claim.py
+++ b/lbry/lbry/schema/claim.py
@@ -167,6 +167,10 @@ class BaseClaim:
     def tags(self) -> List[str]:
         return TagList(self.claim.message.tags)
 
+    @tags.setter
+    def tags(self, tags: List[str]):
+        self.claim.message.tags = TagList.create_normalized(tags)
+
     @property
     def languages(self) -> LanguageList:
         return LanguageList(self.claim.message.languages)

--- a/lbry/lbry/schema/claim.py
+++ b/lbry/lbry/schema/claim.py
@@ -13,7 +13,7 @@ from lbry.schema.base import Signable
 from lbry.schema.mime_types import guess_media_type, guess_stream_type
 from lbry.schema.attrs import (
     Source, Playable, Dimmensional, Fee, Image, Video, Audio,
-    LanguageList, LocationList, ClaimList, ClaimReference
+    LanguageList, LocationList, ClaimList, ClaimReference, TagList
 )
 from lbry.schema.types.v2.claim_pb2 import Claim as ClaimMessage
 
@@ -164,8 +164,8 @@ class BaseClaim:
         return Source(self.claim.message.thumbnail)
 
     @property
-    def tags(self) -> List:
-        return self.claim.message.tags
+    def tags(self) -> List[str]:
+        return TagList(self.claim.message.tags)
 
     @property
     def languages(self) -> LanguageList:

--- a/lbry/lbry/schema/claim.py
+++ b/lbry/lbry/schema/claim.py
@@ -167,10 +167,6 @@ class BaseClaim:
     def tags(self) -> List[str]:
         return TagList(self.claim.message.tags)
 
-    @tags.setter
-    def tags(self, tags: List[str]):
-        self.claim.message.tags = TagList.create_normalized(tags)
-
     @property
     def languages(self) -> LanguageList:
         return LanguageList(self.claim.message.languages)

--- a/lbry/lbry/schema/tags.py
+++ b/lbry/lbry/schema/tags.py
@@ -10,9 +10,4 @@ def normalize_tag(tag: str):
 
 
 def clean_tags(tags: List[str]):
-    clean = []
-    for idx, tag in enumerate(tags):
-        norm_tag = normalize_tag(tag)
-        if norm_tag and norm_tag not in clean[:idx]:
-            clean.append(norm_tag)
-    return clean
+    return [tag for tag in set(normalize_tag(tag) for tag in tags) if tag]

--- a/lbry/lbry/schema/tags.py
+++ b/lbry/lbry/schema/tags.py
@@ -10,4 +10,9 @@ def normalize_tag(tag: str):
 
 
 def clean_tags(tags: List[str]):
-    return [tag for tag in set(normalize_tag(tag) for tag in tags) if tag]
+    clean = []
+    for ind, tag in enumerate(tags):
+        norm_tag = normalize_tag(tag)
+        if norm_tag and norm_tag not in clean[:ind]:
+            clean.append(norm_tag)
+    return clean

--- a/lbry/lbry/schema/tags.py
+++ b/lbry/lbry/schema/tags.py
@@ -11,8 +11,8 @@ def normalize_tag(tag: str):
 
 def clean_tags(tags: List[str]):
     clean = []
-    for ind, tag in enumerate(tags):
+    for idx, tag in enumerate(tags):
         norm_tag = normalize_tag(tag)
-        if norm_tag and norm_tag not in clean[:ind]:
+        if norm_tag and norm_tag not in clean[:idx]:
             clean.append(norm_tag)
     return clean

--- a/lbry/tests/integration/test_claim_commands.py
+++ b/lbry/tests/integration/test_claim_commands.py
@@ -537,6 +537,7 @@ class ChannelCommands(CommandTestCase):
         tx4 = await self.channel_update(claim_id, tags=[' pqr', 'PQr '], clear_tags=True)
         self.assertEqual(tx4['outputs'][0]['value']['tags'], ['pqr'])
 
+
 class StreamCommands(ClaimTestCase):
 
     async def test_create_stream_names(self):

--- a/lbry/tests/unit/schema/test_models.py
+++ b/lbry/tests/unit/schema/test_models.py
@@ -97,6 +97,27 @@ class TestLanguages(TestCase):
             stream.languages.append('en-Zzz-US')
 
 
+class TestTags(TestCase):
+
+    def test_normalize_tags(self):
+        claim = Claim()
+
+        claim.channel.update(tags=['Anime', 'anime', ' aNiMe', 'maNGA '])
+        self.assertCountEqual(claim.channel.tags, ['anime', 'manga'])
+
+        claim.channel.update(tags=['Juri', 'juRi'])
+        self.assertCountEqual(claim.channel.tags, ['anime', 'manga', 'juri'])
+
+        claim.channel.update(tags='Anime')
+        self.assertCountEqual(claim.channel.tags, ['anime', 'manga', 'juri'])
+
+        claim.channel.update(clear_tags=True)
+        self.assertEqual(len(claim.channel.tags), 0)
+
+        claim.channel.update(tags='Anime')
+        self.assertEqual(claim.channel.tags, ['anime'])
+
+
 class TestLocations(TestCase):
 
     def test_location_successful_parsing(self):


### PR DESCRIPTION
fixes #2399. Now, tags are normalized when read, and when claims are created / updated. Duplicate tags (after normalization) are not inserted. Added some unit and integration tests. Maybe `normalize_tag()` and `clean_tags` can be moved to `attrs.py`. (I will merge to rerun the build once the pylint fix is on master).