### PR TITLE
clear metadata when file type changes

### DIFF
--- a/lbry/lbry/schema/claim.py
+++ b/lbry/lbry/schema/claim.py
@@ -179,6 +179,9 @@ class BaseClaim:
     def locations(self) -> LocationList:
         return LocationList(self.claim.message.locations)
 
+    def __delitem__(self, key):
+        self.message.ClearField(key)
+
 
 class Stream(BaseClaim):
 
@@ -214,6 +217,12 @@ class Stream(BaseClaim):
                 kwargs.pop('fee_amount', None)
             )
 
+        source_stream_type = None
+        if self.source.name:
+            _, source_stream_type = guess_media_type(self.source.name)
+        elif self.source.media_type:
+            source_stream_type = guess_stream_type(self.source.media_type)
+
         if 'sd_hash' in kwargs:
             self.source.sd_hash = kwargs.pop('sd_hash')
         if 'file_name' in kwargs:
@@ -231,6 +240,9 @@ class Stream(BaseClaim):
 
         if 'file_size' in kwargs:
             self.source.size = kwargs.pop('file_size')
+
+        if source_stream_type in ('image', 'video', 'audio') and stream_type != source_stream_type:
+            del self[source_stream_type]
 
         if stream_type in ('image', 'video', 'audio'):
             media = getattr(self, stream_type)

--- a/lbry/lbry/schema/claim.py
+++ b/lbry/lbry/schema/claim.py
@@ -179,9 +179,6 @@ class BaseClaim:
     def locations(self) -> LocationList:
         return LocationList(self.claim.message.locations)
 
-    def clear_field_by_name(self, field_name: str):
-        self.message.ClearField(field_name)
-
 
 class Stream(BaseClaim):
 
@@ -217,12 +214,6 @@ class Stream(BaseClaim):
                 kwargs.pop('fee_amount', None)
             )
 
-        source_stream_type = None
-        if self.source.name:
-            _, source_stream_type = guess_media_type(self.source.name)
-        elif self.source.media_type:
-            source_stream_type = guess_stream_type(self.source.media_type)
-
         if 'sd_hash' in kwargs:
             self.source.sd_hash = kwargs.pop('sd_hash')
         if 'file_name' in kwargs:
@@ -241,8 +232,8 @@ class Stream(BaseClaim):
         if 'file_size' in kwargs:
             self.source.size = kwargs.pop('file_size')
 
-        if source_stream_type in ('image', 'video', 'audio') and stream_type != source_stream_type:
-            self.clear_field_by_name(source_stream_type)
+        if self.stream_type is not None and self.stream_type != stream_type:
+            self.message.ClearField(self.stream_type)
 
         if stream_type in ('image', 'video', 'audio'):
             media = getattr(self, stream_type)

--- a/lbry/lbry/schema/claim.py
+++ b/lbry/lbry/schema/claim.py
@@ -179,8 +179,8 @@ class BaseClaim:
     def locations(self) -> LocationList:
         return LocationList(self.claim.message.locations)
 
-    def __delitem__(self, key):
-        self.message.ClearField(key)
+    def clear_field_by_name(self, field_name: str):
+        self.message.ClearField(field_name)
 
 
 class Stream(BaseClaim):
@@ -242,7 +242,7 @@ class Stream(BaseClaim):
             self.source.size = kwargs.pop('file_size')
 
         if source_stream_type in ('image', 'video', 'audio') and stream_type != source_stream_type:
-            del self[source_stream_type]
+            self.clear_field_by_name(source_stream_type)
 
         if stream_type in ('image', 'video', 'audio'):
             media = getattr(self, stream_type)

--- a/lbry/lbry/testcase.py
+++ b/lbry/lbry/testcase.py
@@ -211,8 +211,8 @@ class CommandTestCase(IntegrationTestCase):
             await self.ledger.wait(tx)
         return self.sout(tx)
 
-    def create_upload_file(self, data, suffix=""):
-        file_path = tempfile.mktemp(prefix="tmp", suffix=suffix or "", dir=self.daemon.conf.upload_dir)
+    def create_upload_file(self, data, prefix=None, suffix=None):
+        file_path = tempfile.mktemp(prefix=prefix or "tmp", suffix=suffix or "", dir=self.daemon.conf.upload_dir)
         with open(file_path, 'w+b') as file:
             file.write(data)
             file.flush()
@@ -220,16 +220,17 @@ class CommandTestCase(IntegrationTestCase):
 
     async def stream_create(
             self, name='hovercraft', bid='1.0', file_path=None,
-            data=b'hi!', confirm=True, suffix=None, **kwargs):
+            data=b'hi!', confirm=True, prefix=None, suffix=None, **kwargs):
         if file_path is None:
-            file_path = self.create_upload_file(data=data, suffix=suffix)
+            file_path = self.create_upload_file(data=data, prefix=prefix, suffix=suffix)
         return await self.confirm_and_render(
             self.daemon.jsonrpc_stream_create(name, bid, file_path=file_path, **kwargs), confirm
         )
 
-    async def stream_update(self, claim_id, data=None, suffix=None, confirm=True, **kwargs):
+    async def stream_update(
+            self, claim_id, data=None, prefix=None, suffix=None, confirm=True, **kwargs):
         if data is not None:
-            file_path = self.create_upload_file(data=data, suffix=suffix)
+            file_path = self.create_upload_file(data=data, prefix=prefix, suffix=suffix)
             return await self.confirm_and_render(
                 self.daemon.jsonrpc_stream_update(claim_id, file_path=file_path, **kwargs), confirm
             )

--- a/lbry/tests/integration/test_file_commands.py
+++ b/lbry/tests/integration/test_file_commands.py
@@ -103,8 +103,7 @@ class FileCommands(CommandTestCase):
         # Update the stream and assert the file name is not sanitized, but the suggested file name is
         prefix, suffix = 'derpyderp?', '.ext.'
         san_prefix, san_suffix = 'derpyderp', '.ext'
-        new_file_path = self.create_tempfile(data=b'amazing content', prefix=prefix, suffix=suffix)
-        tx = await self.stream_update(claim_id, file_path=new_file_path)
+        tx = await self.stream_update(claim_id, data=b'amazing content', prefix=prefix, suffix=suffix)
         full_path = (await self.daemon.jsonrpc_get('lbry://' + claim_name, save_file=True)).full_path
         updated_stream = self.daemon.jsonrpc_file_list()[0]
 


### PR DESCRIPTION
This is a first attempt at approaching, fixes #2492. If the stream type of the source of the original claim is dimensional or playable, the appropriate field is cleared. Other metadata seem to be updating correctly. A simple integration test included.