### PR TITLE
use more specific asserts in torba tests

### DIFF
--- a/torba/tests/client_tests/integration/test_network.py
+++ b/torba/tests/client_tests/integration/test_network.py
@@ -18,7 +18,7 @@ class NetworkTests(IntegrationTestCase):
         self.assertEqual(self.ledger.network.remote_height, initial_height + 1)
 
     async def test_server_features(self):
-        self.assertEqual({
+        self.assertDictEqual({
             'genesis_hash': self.conductor.spv_node.coin_class.GENESIS_HASH,
             'hash_function': 'sha256',
             'hosts': {},
@@ -37,7 +37,7 @@ class NetworkTests(IntegrationTestCase):
             'DAILY_FEE': '42'})
         await self.conductor.spv_node.start(self.conductor.blockchain_node)
         await self.ledger.network.on_connected.first
-        self.assertEqual({
+        self.assertDictEqual({
             'genesis_hash': self.conductor.spv_node.coin_class.GENESIS_HASH,
             'hash_function': 'sha256',
             'hosts': {},
@@ -162,7 +162,7 @@ class ServerPickingTestCase(AsyncioTestCase):
         asyncio.ensure_future(network.start())
         await asyncio.wait_for(network.on_connected.first, timeout=1)
         self.assertTrue(network.is_connected)
-        self.assertEqual(network.client.server, ('127.0.0.1', 1337))
+        self.assertTupleEqual(network.client.server, ('127.0.0.1', 1337))
         self.assertTrue(all([not session.is_closing() for session in network.session_pool.available_sessions]))
         # ensure we are connected to all of them after a while
         await asyncio.sleep(1)

--- a/torba/tests/client_tests/integration/test_transactions.py
+++ b/torba/tests/client_tests/integration/test_transactions.py
@@ -148,7 +148,7 @@ class BasicTransactionTests(IntegrationTestCase):
             return summary
         self.conductor.spv_node.server.mempool.transaction_summaries = random_summary
         # 10 unconfirmed txs, all from blockchain wallet
-        sends = list(self.blockchain.send_to_address(address, 10) for _ in range(10))
+        sends = [self.blockchain.send_to_address(address, 10) for _ in range(10)]
         # use batching to reduce issues with send_to_address on cli
         for batch in range(0, len(sends), 10):
             txids = await asyncio.gather(*sends[batch:batch + 10])

--- a/torba/tests/client_tests/unit/test_account.py
+++ b/torba/tests/client_tests/unit/test_account.py
@@ -47,7 +47,7 @@ class TestHierarchicalDeterministicAccount(AsyncioTestCase):
         async with self.account.receiving.address_generator_lock:
             await self.account.receiving._generate_keys(0, 200)
         records = await self.account.receiving.get_address_records()
-        self.assertEqual(201, len(records))
+        self.assertEqual(len(records), 201)
 
     async def test_ensure_address_gap(self):
         account = self.account
@@ -59,7 +59,7 @@ class TestHierarchicalDeterministicAccount(AsyncioTestCase):
             await account.receiving._generate_keys(0, 3)
             await account.receiving._generate_keys(8, 11)
         records = await account.receiving.get_address_records()
-        self.assertEqual(
+        self.assertListEqual(
             [r['pubkey'].n for r in records],
             [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]
         )
@@ -68,7 +68,7 @@ class TestHierarchicalDeterministicAccount(AsyncioTestCase):
         new_keys = await account.receiving.ensure_address_gap()
         self.assertEqual(len(new_keys), 8)
         records = await account.receiving.get_address_records()
-        self.assertEqual(
+        self.assertListEqual(
             [r['pubkey'].n for r in records],
             [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19]
         )
@@ -272,7 +272,7 @@ class TestSingleKeyAccount(AsyncioTestCase):
 
         self.assertIsInstance(account.receiving, SingleKey)
         addresses = await account.receiving.get_addresses()
-        self.assertEqual(addresses, [])
+        self.assertListEqual(addresses, [])
 
         # we have 12, but default gap is 20
         new_keys = await account.receiving.ensure_address_gap()
@@ -280,7 +280,7 @@ class TestSingleKeyAccount(AsyncioTestCase):
         self.assertEqual(new_keys[0], account.public_key.address)
         records = await account.receiving.get_address_records()
         pubkey = records[0].pop('pubkey')
-        self.assertEqual(records, [{
+        self.assertListEqual(records, [{
             'chain': 0,
             'account': account.public_key.address,
             'address': account.public_key.address,

--- a/torba/tests/client_tests/unit/test_coinselection.py
+++ b/torba/tests/client_tests/unit/test_coinselection.py
@@ -75,15 +75,15 @@ class TestCoinSelectionTests(BaseSelectionTestCase):
 
     def test_pick(self):
         utxo_pool = self.estimates(
-            utxo(1 * CENT),
-            utxo(1 * CENT),
-            utxo(3 * CENT),
-            utxo(5 * CENT),
-            utxo(10 * CENT),
+            utxo(1*CENT),
+            utxo(1*CENT),
+            utxo(3*CENT),
+            utxo(5*CENT),
+            utxo(10*CENT),
         )
-        selector = CoinSelector(3 * CENT, 0)
+        selector = CoinSelector(3*CENT, 0)
         match = selector.select(utxo_pool)
-        self.assertListEqual([5 * CENT], [c.txo.amount for c in match])
+        self.assertListEqual([5*CENT], [c.txo.amount for c in match])
 
     def test_confirmed_strategies(self):
         utxo_pool = self.estimates(
@@ -93,14 +93,14 @@ class TestCoinSelectionTests(BaseSelectionTestCase):
             utxo(11*CENT, height=5),
         )
 
-        match = CoinSelector(20 * CENT, 0).select(utxo_pool, "only_confirmed")
+        match = CoinSelector(20*CENT, 0).select(utxo_pool, "only_confirmed")
         self.assertListEqual([5, 5], [c.txo.tx_ref.height for c in match])
-        match = CoinSelector(25 * CENT, 0).select(utxo_pool, "only_confirmed")
+        match = CoinSelector(25*CENT, 0).select(utxo_pool, "only_confirmed")
         self.assertListEqual([], [c.txo.tx_ref.height for c in match])
 
-        match = CoinSelector(20 * CENT, 0).select(utxo_pool, "prefer_confirmed")
+        match = CoinSelector(20*CENT, 0).select(utxo_pool, "prefer_confirmed")
         self.assertListEqual([5, 5], [c.txo.tx_ref.height for c in match])
-        match = CoinSelector(25 * CENT, 0, '\x00').select(utxo_pool, "prefer_confirmed")
+        match = CoinSelector(25*CENT, 0, '\x00').select(utxo_pool, "prefer_confirmed")
         self.assertListEqual([5, 0, -2], [c.txo.tx_ref.height for c in match])
 
 

--- a/torba/tests/client_tests/unit/test_coinselection.py
+++ b/torba/tests/client_tests/unit/test_coinselection.py
@@ -37,13 +37,13 @@ class BaseSelectionTestCase(AsyncioTestCase):
 class TestCoinSelectionTests(BaseSelectionTestCase):
 
     def test_empty_coins(self):
-        self.assertEqual(CoinSelector(0, 0).select([]), [])
+        self.assertListEqual(CoinSelector(0, 0).select([]), [])
 
     def test_skip_binary_search_if_total_not_enough(self):
         fee = utxo(CENT).get_estimator(self.ledger).fee
         big_pool = self.estimates(utxo(CENT+fee) for _ in range(100))
         selector = CoinSelector(101 * CENT, 0)
-        self.assertEqual(selector.select(big_pool), [])
+        self.assertListEqual(selector.select(big_pool), [])
         self.assertEqual(selector.tries, 0)  # Never tried.
         # check happy path
         selector = CoinSelector(100 * CENT, 0)
@@ -59,7 +59,7 @@ class TestCoinSelectionTests(BaseSelectionTestCase):
         )
         selector = CoinSelector(CENT, 0)
         match = selector.select(utxo_pool)
-        self.assertEqual([CENT + fee], [c.txo.amount for c in match])
+        self.assertListEqual([CENT + fee], [c.txo.amount for c in match])
         self.assertTrue(selector.exact_match)
 
     def test_random_draw(self):
@@ -70,20 +70,20 @@ class TestCoinSelectionTests(BaseSelectionTestCase):
         )
         selector = CoinSelector(CENT, 0, '\x00')
         match = selector.select(utxo_pool)
-        self.assertEqual([2 * CENT], [c.txo.amount for c in match])
+        self.assertListEqual([2 * CENT], [c.txo.amount for c in match])
         self.assertFalse(selector.exact_match)
 
     def test_pick(self):
         utxo_pool = self.estimates(
-            utxo(1*CENT),
-            utxo(1*CENT),
-            utxo(3*CENT),
-            utxo(5*CENT),
-            utxo(10*CENT),
+            utxo(1 * CENT),
+            utxo(1 * CENT),
+            utxo(3 * CENT),
+            utxo(5 * CENT),
+            utxo(10 * CENT),
         )
-        selector = CoinSelector(3*CENT, 0)
+        selector = CoinSelector(3 * CENT, 0)
         match = selector.select(utxo_pool)
-        self.assertEqual([5*CENT], [c.txo.amount for c in match])
+        self.assertListEqual([5 * CENT], [c.txo.amount for c in match])
 
     def test_confirmed_strategies(self):
         utxo_pool = self.estimates(
@@ -93,15 +93,15 @@ class TestCoinSelectionTests(BaseSelectionTestCase):
             utxo(11*CENT, height=5),
         )
 
-        match = CoinSelector(20*CENT, 0).select(utxo_pool, "only_confirmed")
-        self.assertEqual([5, 5], [c.txo.tx_ref.height for c in match])
-        match = CoinSelector(25*CENT, 0).select(utxo_pool, "only_confirmed")
-        self.assertEqual([], [c.txo.tx_ref.height for c in match])
+        match = CoinSelector(20 * CENT, 0).select(utxo_pool, "only_confirmed")
+        self.assertListEqual([5, 5], [c.txo.tx_ref.height for c in match])
+        match = CoinSelector(25 * CENT, 0).select(utxo_pool, "only_confirmed")
+        self.assertListEqual([], [c.txo.tx_ref.height for c in match])
 
-        match = CoinSelector(20*CENT, 0).select(utxo_pool, "prefer_confirmed")
-        self.assertEqual([5, 5], [c.txo.tx_ref.height for c in match])
-        match = CoinSelector(25*CENT, 0, '\x00').select(utxo_pool, "prefer_confirmed")
-        self.assertEqual([5, 0, -2], [c.txo.tx_ref.height for c in match])
+        match = CoinSelector(20 * CENT, 0).select(utxo_pool, "prefer_confirmed")
+        self.assertListEqual([5, 5], [c.txo.tx_ref.height for c in match])
+        match = CoinSelector(25 * CENT, 0, '\x00').select(utxo_pool, "prefer_confirmed")
+        self.assertListEqual([5, 0, -2], [c.txo.tx_ref.height for c in match])
 
 
 class TestOfficialBitcoinCoinSelectionTests(BaseSelectionTestCase):
@@ -136,20 +136,20 @@ class TestOfficialBitcoinCoinSelectionTests(BaseSelectionTestCase):
         )
 
         # Select 1 Cent
-        self.assertEqual([1 * CENT], search(utxo_pool, 1 * CENT, 0.5 * CENT))
+        self.assertListEqual([1 * CENT], search(utxo_pool, 1 * CENT, 0.5 * CENT))
 
         # Select 2 Cent
-        self.assertEqual([2 * CENT], search(utxo_pool, 2 * CENT, 0.5 * CENT))
+        self.assertListEqual([2 * CENT], search(utxo_pool, 2 * CENT, 0.5 * CENT))
 
         # Select 5 Cent
-        self.assertEqual([3 * CENT, 2 * CENT], search(utxo_pool, 5 * CENT, 0.5 * CENT))
+        self.assertListEqual([3 * CENT, 2 * CENT], search(utxo_pool, 5 * CENT, 0.5 * CENT))
 
         # Select 11 Cent, not possible
-        self.assertEqual([], search(utxo_pool, 11 * CENT, 0.5 * CENT))
+        self.assertListEqual([], search(utxo_pool, 11 * CENT, 0.5 * CENT))
 
         # Select 10 Cent
         utxo_pool += self.estimates(utxo(5 * CENT))
-        self.assertEqual(
+        self.assertListEqual(
             [4 * CENT, 3 * CENT, 2 * CENT, 1 * CENT],
             search(utxo_pool, 10 * CENT, 0.5 * CENT)
         )
@@ -157,18 +157,18 @@ class TestOfficialBitcoinCoinSelectionTests(BaseSelectionTestCase):
         # Negative effective value
         # Select 10 Cent but have 1 Cent not be possible because too small
         # TODO: bitcoin has [5, 3, 2]
-        self.assertEqual(
+        self.assertListEqual(
             [4 * CENT, 3 * CENT, 2 * CENT, 1 * CENT],
             search(utxo_pool, 10 * CENT, 5000)
         )
 
         # Select 0.25 Cent, not possible
-        self.assertEqual(search(utxo_pool, 0.25 * CENT, 0.5 * CENT), [])
+        self.assertListEqual(search(utxo_pool, 0.25 * CENT, 0.5 * CENT), [])
 
         # Iteration exhaustion test
         utxo_pool, target = self.make_hard_case(17)
         selector = CoinSelector(target, 0)
-        self.assertEqual(selector.select(utxo_pool, 'branch_and_bound'), [])
+        self.assertListEqual(selector.select(utxo_pool, 'branch_and_bound'), [])
         self.assertEqual(selector.tries, MAXIMUM_TRIES)  # Should exhaust
         utxo_pool, target = self.make_hard_case(14)
         self.assertIsNotNone(search(utxo_pool, target, 0))  # Should not exhaust
@@ -181,7 +181,7 @@ class TestOfficialBitcoinCoinSelectionTests(BaseSelectionTestCase):
             utxo(7 * CENT),
             utxo(2 * CENT)
         ] + [utxo(5 * CENT)]*50000)
-        self.assertEqual(
+        self.assertListEqual(
             [7 * CENT, 7 * CENT, 7 * CENT, 7 * CENT, 2 * CENT],
             search(utxo_pool, 30 * CENT, 5000)
         )
@@ -189,4 +189,4 @@ class TestOfficialBitcoinCoinSelectionTests(BaseSelectionTestCase):
         # Select 1 Cent with pool of only greater than 5 Cent
         utxo_pool = self.estimates(utxo(i * CENT) for i in range(5, 21))
         for _ in range(100):
-            self.assertEqual(search(utxo_pool, 1 * CENT, 2 * CENT), [])
+            self.assertListEqual(search(utxo_pool, 1 * CENT, 2 * CENT), [])

--- a/torba/tests/client_tests/unit/test_database.py
+++ b/torba/tests/client_tests/unit/test_database.py
@@ -60,17 +60,17 @@ class TestAIOSQLite(AsyncioTestCase):
 class TestQueryBuilder(unittest.TestCase):
 
     def test_dot(self):
-        self.assertEqual(
+        self.assertTupleEqual(
             constraints_to_sql({'txo.position': 18}),
             ('txo.position = :txo_position0', {'txo_position0': 18})
         )
-        self.assertEqual(
+        self.assertTupleEqual(
             constraints_to_sql({'txo.position#6': 18}),
             ('txo.position = :txo_position6', {'txo_position6': 18})
         )
 
     def test_any(self):
-        self.assertEqual(
+        self.assertTupleEqual(
             constraints_to_sql({
                 'ages__any': {
                     'txo.age__gt': 18,
@@ -84,41 +84,41 @@ class TestQueryBuilder(unittest.TestCase):
         )
 
     def test_in(self):
-        self.assertEqual(
+        self.assertTupleEqual(
             constraints_to_sql({'txo.age__in#2': [18, 38]}),
             ('txo.age IN (:txo_age__in2_0, :txo_age__in2_1)', {
                 'txo_age__in2_0': 18,
                 'txo_age__in2_1': 38
             })
         )
-        self.assertEqual(
+        self.assertTupleEqual(
             constraints_to_sql({'txo.name__in': ('abc123', 'def456')}),
             ('txo.name IN (:txo_name__in0_0, :txo_name__in0_1)', {
                 'txo_name__in0_0': 'abc123',
                 'txo_name__in0_1': 'def456'
             })
         )
-        self.assertEqual(
+        self.assertTupleEqual(
             constraints_to_sql({'txo.age__in': 'SELECT age from ages_table'}),
             ('txo.age IN (SELECT age from ages_table)', {})
         )
 
     def test_not_in(self):
-        self.assertEqual(
+        self.assertTupleEqual(
             constraints_to_sql({'txo.age__not_in': [18, 38]}),
             ('txo.age NOT IN (:txo_age__not_in0_0, :txo_age__not_in0_1)', {
                 'txo_age__not_in0_0': 18,
                 'txo_age__not_in0_1': 38
             })
         )
-        self.assertEqual(
+        self.assertTupleEqual(
             constraints_to_sql({'txo.name__not_in': ('abc123', 'def456')}),
             ('txo.name NOT IN (:txo_name__not_in0_0, :txo_name__not_in0_1)', {
                 'txo_name__not_in0_0': 'abc123',
                 'txo_name__not_in0_1': 'def456'
             })
         )
-        self.assertEqual(
+        self.assertTupleEqual(
             constraints_to_sql({'txo.age__not_in': 'SELECT age from ages_table'}),
             ('txo.age NOT IN (SELECT age from ages_table)', {})
         )
@@ -128,11 +128,11 @@ class TestQueryBuilder(unittest.TestCase):
             constraints_to_sql({'ages__in': 9})
 
     def test_query(self):
-        self.assertEqual(
+        self.assertTupleEqual(
             query("select * from foo"),
             ("select * from foo", {})
         )
-        self.assertEqual(
+        self.assertTupleEqual(
             query(
                 "select * from foo",
                 a__not='b', b__in='select * from blah where c=:$c',
@@ -146,11 +146,11 @@ class TestQueryBuilder(unittest.TestCase):
         )
 
     def test_query_order_by(self):
-        self.assertEqual(
+        self.assertTupleEqual(
             query("select * from foo", order_by='foo'),
             ("select * from foo ORDER BY foo", {})
         )
-        self.assertEqual(
+        self.assertTupleEqual(
             query("select * from foo", order_by=['foo', 'bar']),
             ("select * from foo ORDER BY foo, bar", {})
         )
@@ -158,15 +158,15 @@ class TestQueryBuilder(unittest.TestCase):
             query("select * from foo", order_by={'foo': 'bar'})
 
     def test_query_limit_offset(self):
-        self.assertEqual(
+        self.assertTupleEqual(
             query("select * from foo", limit=10),
             ("select * from foo LIMIT 10", {})
         )
-        self.assertEqual(
+        self.assertTupleEqual(
             query("select * from foo", offset=10),
             ("select * from foo OFFSET 10", {})
         )
-        self.assertEqual(
+        self.assertTupleEqual(
             query("select * from foo", limit=20, offset=10),
             ("select * from foo LIMIT 20 OFFSET 10", {})
         )
@@ -188,7 +188,7 @@ class TestQueryBuilder(unittest.TestCase):
             "(one LIKE 'o' OR two = 2) AND "
             "a0 = 3 AND a00 = 1 AND a00a = 2 AND a00aa = 4 "
             "AND ahash = X'b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9' "
-            "ORDER BY b LIMIT 10",
+            "ORDER BY b LIMIT 10"
         )
 
 
@@ -264,7 +264,7 @@ class TestQueries(AsyncioTestCase):
         for height in range(1, 1200):
             tx = await self.create_tx_from_txo(tx.outputs[0], account, height=height)
         variable_limit = self.ledger.db.MAX_QUERY_VARIABLES
-        for limit in range(variable_limit-2, variable_limit+2):
+        for limit in range(variable_limit - 2, variable_limit + 2):
             txs = await self.ledger.get_transactions(
                 accounts=self.wallet.accounts, limit=limit, order_by='height asc')
             self.assertEqual(len(txs), limit)
@@ -286,7 +286,7 @@ class TestQueries(AsyncioTestCase):
 
         self.assertEqual(0, await self.ledger.db.get_transaction_count(accounts=[account1, account2, account3]))
         self.assertEqual(0, await self.ledger.db.get_utxo_count())
-        self.assertEqual([], await self.ledger.db.get_utxos())
+        self.assertListEqual([], await self.ledger.db.get_utxos())
         self.assertEqual(0, await self.ledger.db.get_txo_count())
         self.assertEqual(0, await self.ledger.db.get_balance(wallet=wallet1))
         self.assertEqual(0, await self.ledger.db.get_balance(wallet=wallet2))
@@ -337,18 +337,18 @@ class TestQueries(AsyncioTestCase):
         self.assertEqual(10**8, await self.ledger.db.get_balance(accounts=[account3]))
 
         txs = await self.ledger.db.get_transactions(accounts=[account1, account2])
-        self.assertEqual([tx3.id, tx2.id, tx1.id], [tx.id for tx in txs])
-        self.assertEqual([3, 2, 1], [tx.height for tx in txs])
+        self.assertListEqual([tx3.id, tx2.id, tx1.id], [tx.id for tx in txs])
+        self.assertListEqual([3, 2, 1], [tx.height for tx in txs])
 
         txs = await self.ledger.db.get_transactions(wallet=wallet1, accounts=wallet1.accounts)
-        self.assertEqual([tx2.id, tx1.id], [tx.id for tx in txs])
+        self.assertListEqual([tx2.id, tx1.id], [tx.id for tx in txs])
         self.assertEqual(txs[0].inputs[0].is_my_account, True)
         self.assertEqual(txs[0].outputs[0].is_my_account, False)
         self.assertEqual(txs[1].inputs[0].is_my_account, False)
         self.assertEqual(txs[1].outputs[0].is_my_account, True)
 
         txs = await self.ledger.db.get_transactions(wallet=wallet2, accounts=[account2])
-        self.assertEqual([tx3.id, tx2.id], [tx.id for tx in txs])
+        self.assertListEqual([tx3.id, tx2.id], [tx.id for tx in txs])
         self.assertEqual(txs[0].inputs[0].is_my_account, True)
         self.assertEqual(txs[0].outputs[0].is_my_account, False)
         self.assertEqual(txs[1].inputs[0].is_my_account, False)
@@ -369,11 +369,11 @@ class TestQueries(AsyncioTestCase):
         # height 0 sorted to the top with the rest in descending order
         tx4 = await self.create_tx_from_nothing(account1, 0)
         txos = await self.ledger.db.get_txos()
-        self.assertEqual([0, 2, 2, 1], [txo.tx_ref.height for txo in txos])
-        self.assertEqual([tx4.id, tx2.id, tx2b.id, tx1.id], [txo.tx_ref.id for txo in txos])
+        self.assertListEqual([0, 2, 2, 1], [txo.tx_ref.height for txo in txos])
+        self.assertListEqual([tx4.id, tx2.id, tx2b.id, tx1.id], [txo.tx_ref.id for txo in txos])
         txs = await self.ledger.db.get_transactions(accounts=[account1, account2])
-        self.assertEqual([0, 3, 2, 1], [tx.height for tx in txs])
-        self.assertEqual([tx4.id, tx3.id, tx2.id, tx1.id], [tx.id for tx in txs])
+        self.assertListEqual([0, 3, 2, 1], [tx.height for tx in txs])
+        self.assertListEqual([tx4.id, tx3.id, tx2.id, tx1.id], [tx.id for tx in txs])
 
 
 class TestUpgrade(AsyncioTestCase):
@@ -415,10 +415,10 @@ class TestUpgrade(AsyncioTestCase):
 
         # initial open, pre-version enabled db
         self.ledger.db.SCHEMA_VERSION = None
-        self.assertEqual(self.get_tables(), [])
+        self.assertListEqual(self.get_tables(), [])
         await self.ledger.db.open()
         self.assertEqual(self.get_tables(), ['account_address', 'pubkey_address', 'tx', 'txi', 'txo'])
-        self.assertEqual(self.get_addresses(), [])
+        self.assertListEqual(self.get_addresses(), [])
         self.add_address('address1')
         await self.ledger.db.close()
 
@@ -426,18 +426,18 @@ class TestUpgrade(AsyncioTestCase):
         self.ledger.db.SCHEMA_VERSION = '1.0'
         await self.ledger.db.open()
         self.assertEqual(self.get_version(), '1.0')
-        self.assertEqual(self.get_tables(), ['account_address', 'pubkey_address', 'tx', 'txi', 'txo', 'version'])
-        self.assertEqual(self.get_addresses(), [])  # address1 deleted during version upgrade
+        self.assertListEqual(self.get_tables(), ['account_address', 'pubkey_address', 'tx', 'txi', 'txo', 'version'])
+        self.assertListEqual(self.get_addresses(), [])  # address1 deleted during version upgrade
         self.add_address('address2')
         await self.ledger.db.close()
 
         # nothing changes
         self.assertEqual(self.get_version(), '1.0')
-        self.assertEqual(self.get_tables(), ['account_address', 'pubkey_address', 'tx', 'txi', 'txo', 'version'])
+        self.assertListEqual(self.get_tables(), ['account_address', 'pubkey_address', 'tx', 'txi', 'txo', 'version'])
         await self.ledger.db.open()
         self.assertEqual(self.get_version(), '1.0')
-        self.assertEqual(self.get_tables(), ['account_address', 'pubkey_address', 'tx', 'txi', 'txo', 'version'])
-        self.assertEqual(self.get_addresses(), ['address2'])
+        self.assertListEqual(self.get_tables(), ['account_address', 'pubkey_address', 'tx', 'txi', 'txo', 'version'])
+        self.assertListEqual(self.get_addresses(), ['address2'])
         await self.ledger.db.close()
 
         # upgrade version, database reset
@@ -447,8 +447,8 @@ class TestUpgrade(AsyncioTestCase):
         """
         await self.ledger.db.open()
         self.assertEqual(self.get_version(), '1.1')
-        self.assertEqual(self.get_tables(), ['account_address', 'foo', 'pubkey_address', 'tx', 'txi', 'txo', 'version'])
-        self.assertEqual(self.get_addresses(), [])  # all tables got reset
+        self.assertListEqual(self.get_tables(), ['account_address', 'foo', 'pubkey_address', 'tx', 'txi', 'txo', 'version'])
+        self.assertListEqual(self.get_addresses(), [])  # all tables got reset
         await self.ledger.db.close()
 
 

--- a/torba/tests/client_tests/unit/test_hash.py
+++ b/torba/tests/client_tests/unit/test_hash.py
@@ -23,7 +23,7 @@ class TestAESEncryptDecrypt(TestCase):
            'ZmZmZmZmZmZmZmZmZmZmZjlrKptoKD+MFwDxcg3XtCD9qz8UWhEhq/TVJT5+Mtp2a8sE'
            'CaO6WQj7fYsWGu2Hvbc0qYqxdN0HeTsiO+cZRo3eJISgr3F+rXFYi5oSBlD2'
         )
-        self.assertEqual(
+        self.assertTupleEqual(
             aes_decrypt(self.password, self.expected),
             (self.message, b'f' * 16)
         )

--- a/torba/tests/client_tests/unit/test_headers.py
+++ b/torba/tests/client_tests/unit/test_headers.py
@@ -35,7 +35,7 @@ class BasicHeadersTests(BitcoinHeadersTestCase):
 
     async def test_serialization(self):
         h = await self.get_headers()
-        self.assertEqual(h[0], {
+        self.assertDictEqual(h[0], {
             'bits': 486604799,
             'block_height': 0,
             'merkle_root': b'4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b',
@@ -44,7 +44,7 @@ class BasicHeadersTests(BitcoinHeadersTestCase):
             'timestamp': 1231006505,
             'version': 1
         })
-        self.assertEqual(h[self.RETARGET_BLOCK-1], {
+        self.assertDictEqual(h[self.RETARGET_BLOCK-1], {
             'bits': 486604799,
             'block_height': 32255,
             'merkle_root': b'89b4f223789e40b5b475af6483bb05bceda54059e17d2053334b358f6bb310ac',
@@ -53,7 +53,7 @@ class BasicHeadersTests(BitcoinHeadersTestCase):
             'timestamp': 1262152739,
             'version': 1
         })
-        self.assertEqual(h[self.RETARGET_BLOCK], {
+        self.assertDictEqual(h[self.RETARGET_BLOCK], {
             'bits': 486594666,
             'block_height': 32256,
             'merkle_root': b'64b5e5f5a262f47af443a0120609206a3305877693edfe03e994f20a024ab627',
@@ -62,7 +62,7 @@ class BasicHeadersTests(BitcoinHeadersTestCase):
             'timestamp': 1262153464,
             'version': 1
         })
-        self.assertEqual(h[self.RETARGET_BLOCK+1], {
+        self.assertDictEqual(h[self.RETARGET_BLOCK+1], {
             'bits': 486594666,
             'block_height': 32257,
             'merkle_root': b'4d1488981f08b3037878193297dbac701a2054e0f803d4424fe6a4d763d62334',

--- a/torba/tests/client_tests/unit/test_ledger.py
+++ b/torba/tests/client_tests/unit/test_ledger.py
@@ -90,8 +90,8 @@ class TestSynchronization(LedgerTestCase):
             'abcd03': hexlify(get_transaction(get_output(3)).raw),
         })
         await self.ledger.update_history(address, '')
-        self.assertEqual(self.ledger.network.get_history_called, [address])
-        self.assertEqual(self.ledger.network.get_transaction_called, ['abcd01', 'abcd02', 'abcd03'])
+        self.assertListEqual(self.ledger.network.get_history_called, [address])
+        self.assertListEqual(self.ledger.network.get_transaction_called, ['abcd01', 'abcd02', 'abcd03'])
 
         address_details = await self.ledger.db.get_address(address=address)
         self.assertEqual(
@@ -104,16 +104,16 @@ class TestSynchronization(LedgerTestCase):
         self.ledger.network.get_history_called = []
         self.ledger.network.get_transaction_called = []
         await self.ledger.update_history(address, '')
-        self.assertEqual(self.ledger.network.get_history_called, [address])
-        self.assertEqual(self.ledger.network.get_transaction_called, [])
+        self.assertListEqual(self.ledger.network.get_history_called, [address])
+        self.assertListEqual(self.ledger.network.get_transaction_called, [])
 
         self.ledger.network.history.append({'tx_hash': 'abcd04', 'height': 3})
         self.ledger.network.transaction['abcd04'] = hexlify(get_transaction(get_output(4)).raw)
         self.ledger.network.get_history_called = []
         self.ledger.network.get_transaction_called = []
         await self.ledger.update_history(address, '')
-        self.assertEqual(self.ledger.network.get_history_called, [address])
-        self.assertEqual(self.ledger.network.get_transaction_called, ['abcd04'])
+        self.assertListEqual(self.ledger.network.get_history_called, [address])
+        self.assertListEqual(self.ledger.network.get_transaction_called, ['abcd04'])
         address_details = await self.ledger.db.get_address(address=address)
         self.assertEqual(
             address_details['history'],

--- a/torba/tests/client_tests/unit/test_script.py
+++ b/torba/tests/client_tests/unit/test_script.py
@@ -24,14 +24,14 @@ def parse(opcodes, source):
 class TestScriptTemplates(unittest.TestCase):
 
     def test_push_data(self):
-        self.assertEqual(parse(
+        self.assertDictEqual(parse(
                 (PUSH_SINGLE('script_hash'),),
                 (b'abcdef',)
             ), {
                 'script_hash': b'abcdef'
             }
         )
-        self.assertEqual(parse(
+        self.assertDictEqual(parse(
                 (PUSH_SINGLE('first'), PUSH_INTEGER('rating')),
                 (b'Satoshi', (1000).to_bytes(2, 'little'))
             ), {
@@ -39,7 +39,7 @@ class TestScriptTemplates(unittest.TestCase):
                 'rating': 1000,
             }
         )
-        self.assertEqual(parse(
+        self.assertDictEqual(parse(
                 (OP_HASH160, PUSH_SINGLE('script_hash'), OP_EQUAL),
                 (OP_HASH160, b'abcdef', OP_EQUAL)
             ), {
@@ -48,21 +48,21 @@ class TestScriptTemplates(unittest.TestCase):
         )
 
     def test_push_data_many(self):
-        self.assertEqual(parse(
+        self.assertDictEqual(parse(
                 (PUSH_MANY('names'),),
                 (b'amit',)
             ), {
                 'names': [b'amit']
             }
         )
-        self.assertEqual(parse(
+        self.assertDictEqual(parse(
                 (PUSH_MANY('names'),),
                 (b'jeremy', b'amit', b'victor')
             ), {
                 'names': [b'jeremy', b'amit', b'victor']
             }
         )
-        self.assertEqual(parse(
+        self.assertDictEqual(parse(
                 (OP_HASH160, PUSH_MANY('names'), OP_EQUAL),
                 (OP_HASH160, b'grin', b'jack', OP_EQUAL)
             ), {
@@ -71,7 +71,7 @@ class TestScriptTemplates(unittest.TestCase):
         )
 
     def test_push_data_mixed(self):
-        self.assertEqual(parse(
+        self.assertDictEqual(parse(
                 (PUSH_SINGLE('CEO'), PUSH_MANY('Devs'), PUSH_SINGLE('CTO'), PUSH_SINGLE('State')),
                 (b'jeremy', b'lex', b'amit', b'victor', b'jack', b'grin', b'NH')
             ), {
@@ -83,7 +83,7 @@ class TestScriptTemplates(unittest.TestCase):
         )
 
     def test_push_data_many_separated(self):
-        self.assertEqual(parse(
+        self.assertDictEqual(parse(
                 (PUSH_MANY('Chiefs'), OP_HASH160, PUSH_MANY('Devs')),
                 (b'jeremy', b'grin', OP_HASH160, b'lex', b'jack')
             ), {
@@ -135,16 +135,16 @@ class TestRedeemScriptHash(unittest.TestCase):
         )
         subscript1 = src1.values['script']
         self.assertEqual(src1.template.name, 'script_hash')
-        self.assertEqual([hexlify(v) for v in src1.values['signatures']], sigs)
-        self.assertEqual([hexlify(p) for p in subscript1.values['pubkeys']], pubkeys)
+        self.assertListEqual([hexlify(v) for v in src1.values['signatures']], sigs)
+        self.assertListEqual([hexlify(p) for p in subscript1.values['pubkeys']], pubkeys)
         self.assertEqual(subscript1.values['signatures_count'], len(sigs))
         self.assertEqual(subscript1.values['pubkeys_count'], len(pubkeys))
         # now we test that it will round trip
         src2 = BaseInputScript(src1.source)
         subscript2 = src2.values['script']
         self.assertEqual(src2.template.name, 'script_hash')
-        self.assertEqual([hexlify(v) for v in src2.values['signatures']], sigs)
-        self.assertEqual([hexlify(p) for p in subscript2.values['pubkeys']], pubkeys)
+        self.assertListEqual([hexlify(v) for v in src2.values['signatures']], sigs)
+        self.assertListEqual([hexlify(p) for p in subscript2.values['pubkeys']], pubkeys)
         self.assertEqual(subscript2.values['signatures_count'], len(sigs))
         self.assertEqual(subscript2.values['pubkeys_count'], len(pubkeys))
         return hexlify(src1.source)

--- a/torba/tests/client_tests/unit/test_stream_controller.py
+++ b/torba/tests/client_tests/unit/test_stream_controller.py
@@ -9,7 +9,7 @@ class StreamControllerTestCase(AsyncioTestCase):
         controller.stream.listen(on_data=events.append)
         controller.add("yo")
         controller.add("yo")
-        self.assertEqual(events, ["yo", "yo"])
+        self.assertListEqual(events, ["yo", "yo"])
 
     def test_unique_events(self):
         events = []
@@ -17,4 +17,4 @@ class StreamControllerTestCase(AsyncioTestCase):
         controller.stream.listen(on_data=events.append)
         controller.add("yo")
         controller.add("yo")
-        self.assertEqual(events, ["yo"])
+        self.assertListEqual(events, ["yo"])

--- a/torba/tests/client_tests/unit/test_transaction.py
+++ b/torba/tests/client_tests/unit/test_transaction.py
@@ -294,9 +294,9 @@ class TransactionIOBalancing(AsyncioTestCase):
             [self.txo(3)]  # outputs
         )
         # best UTXO match is 5 (as UTXO 3 will be short 0.02 to cover fees)
-        self.assertEqual(self.inputs(tx), [5])
+        self.assertListEqual(self.inputs(tx), [5])
         # a change of 1.98 is added to reach balance
-        self.assertEqual(self.outputs(tx), [3, 1.98])
+        self.assertListEqual(self.outputs(tx), [3, 1.98])
 
         await self.ledger.release_outputs(utxos)
 
@@ -306,8 +306,8 @@ class TransactionIOBalancing(AsyncioTestCase):
             [self.txo(2.98)]  # outputs
         )
         # best UTXO match is 3 and no change is needed
-        self.assertEqual(self.inputs(tx), [3])
-        self.assertEqual(self.outputs(tx), [2.98])
+        self.assertListEqual(self.inputs(tx), [3])
+        self.assertListEqual(self.outputs(tx), [2.98])
 
         await self.ledger.release_outputs(utxos)
 
@@ -317,9 +317,9 @@ class TransactionIOBalancing(AsyncioTestCase):
             [self.txo(11)]             # outputs
         )
         # additional input is chosen (UTXO 3)
-        self.assertEqual([10, 3], self.inputs(tx))
+        self.assertListEqual([10, 3], self.inputs(tx))
         # change is now needed to consume extra input
-        self.assertEqual([11, 1.96], self.outputs(tx))
+        self.assertListEqual([11, 1.96], self.outputs(tx))
 
         await self.ledger.release_outputs(utxos)
 
@@ -328,9 +328,9 @@ class TransactionIOBalancing(AsyncioTestCase):
             [self.txi(self.txo(10))],  # inputs
             []                         # outputs
         )
-        self.assertEqual([10], self.inputs(tx))
+        self.assertListEqual([10], self.inputs(tx))
         # missing change added to consume the amount
-        self.assertEqual([9.98], self.outputs(tx))
+        self.assertListEqual([9.98], self.outputs(tx))
 
         await self.ledger.release_outputs(utxos)
 
@@ -340,6 +340,6 @@ class TransactionIOBalancing(AsyncioTestCase):
             []                           # outputs
         )
         # UTXO 1 is added to cover some of the fee
-        self.assertEqual([0.01, 1], self.inputs(tx))
+        self.assertListEqual([0.01, 1], self.inputs(tx))
         # change is now needed to consume extra input
-        self.assertEqual([0.97], self.outputs(tx))
+        self.assertListEqual([0.97], self.outputs(tx))

--- a/torba/tests/client_tests/unit/test_wallet.py
+++ b/torba/tests/client_tests/unit/test_wallet.py
@@ -20,7 +20,7 @@ class TestWalletCreation(AsyncioTestCase):
     def test_create_wallet_and_accounts(self):
         wallet = Wallet()
         self.assertEqual(wallet.name, 'Wallet')
-        self.assertEqual(wallet.accounts, [])
+        self.assertListEqual(wallet.accounts, [])
 
         account1 = wallet.generate_account(self.btc_ledger)
         wallet.generate_account(self.btc_ledger)


### PR DESCRIPTION
Use `assertListEqual`/`assertTupleEqual`/`assertDictEqual` instead of `asserEqual`.
This PR doesn't conflict with #2498, in which `assertTrue`/`assertFalse` replaces `assertEqual`.