### PR TITLE
fix resolving fixed peers from an ipv6 connection

### DIFF
--- a/lbry/lbry/dht/peer.py
+++ b/lbry/lbry/dht/peer.py
@@ -161,7 +161,7 @@ class KademliaPeer:
         if self.tcp_port is not None and not 1 <= self.tcp_port <= 65535:
             raise ValueError("invalid tcp port")
         if not is_valid_ipv4(self.address):
-            raise ValueError("invalid ip address")
+            raise ValueError(f"invalid ip address: '{self.address}'")
 
     def update_tcp_port(self, tcp_port: int):
         self.tcp_port = tcp_port

--- a/lbry/lbry/utils.py
+++ b/lbry/lbry/utils.py
@@ -192,7 +192,8 @@ async def resolve_host(url: str, port: int, proto: str) -> str:
     return (await loop.getaddrinfo(
         url, port,
         proto=socket.IPPROTO_TCP if proto == 'tcp' else socket.IPPROTO_UDP,
-        type=socket.SOCK_STREAM if proto == 'tcp' else socket.SOCK_DGRAM
+        type=socket.SOCK_STREAM if proto == 'tcp' else socket.SOCK_DGRAM,
+        family=socket.AF_INET
     ))[0][4][0]
 
 


### PR DESCRIPTION
This fixes downloading from fixed peers not working on certain mobile networks (Sprint, T-Mobile)