### PR TITLE
added `wallet` `lock`/`unlock`/`encrypt`/`decrypt` and `status` APIs

### DIFF
--- a/lbry/lbry/extras/daemon/Components.py
+++ b/lbry/lbry/extras/daemon/Components.py
@@ -252,8 +252,6 @@ class WalletComponent(Component):
                 'blocks': max(local_height, 0),
                 'blocks_behind': max(remote_height - local_height, 0),
                 'best_blockhash': best_hash,
-                'is_encrypted': self.wallet_manager.use_encryption,
-                'is_locked': not self.wallet_manager.is_wallet_unlocked,
             }
 
     async def start(self):

--- a/lbry/lbry/extras/daemon/Daemon.py
+++ b/lbry/lbry/extras/daemon/Daemon.py
@@ -1166,6 +1166,77 @@ class Daemon(metaclass=JSONRPCServerType):
         )
         return dict_values_to_lbc(balance)
 
+    @requires(WALLET_COMPONENT)
+    def jsonrpc_wallet_unlock(self, password, wallet_id=None):
+        """
+        Unlock an encrypted wallet
+
+        Usage:
+            wallet_unlock (<password> | --password=<password>) [--wallet_id=<wallet_id>]
+
+        Options:
+            --password=<password>      : (str) password to use for unlocking
+            --wallet_id=<wallet_id>    : (str) restrict operation to specific wallet
+
+        Returns:
+            (bool) true if wallet is unlocked, otherwise false
+        """
+        wallet = self.wallet_manager.get_wallet_or_default(wallet_id)
+        return wallet.unlock(password)
+
+    @requires(WALLET_COMPONENT)
+    def jsonrpc_wallet_lock(self, wallet_id=None):
+        """
+        Lock an unlocked wallet
+
+        Usage:
+            wallet_lock [--wallet_id=<wallet_id>]
+
+        Options:
+            --wallet_id=<wallet_id>    : (str) restrict operation to specific wallet
+
+        Returns:
+            (bool) true if wallet is locked, otherwise false
+        """
+        wallet = self.wallet_manager.get_wallet_or_default(wallet_id)
+        return wallet.lock()
+
+    @requires(WALLET_COMPONENT, conditions=[WALLET_IS_UNLOCKED])
+    def jsonrpc_wallet_decrypt(self, wallet_id=None):
+        """
+        Decrypt an encrypted wallet, this will remove the wallet password. The wallet must be unlocked to decrypt it
+
+        Usage:
+            wallet_decrypt [--wallet_id=<wallet_id>]
+
+        Options:
+            --wallet_id=<wallet_id>    : (str) restrict operation to specific wallet
+
+        Returns:
+            (bool) true if wallet is decrypted, otherwise false
+        """
+        wallet = self.wallet_manager.get_wallet_or_default(wallet_id)
+        return wallet.decrypt()
+
+    @requires(WALLET_COMPONENT, conditions=[WALLET_IS_UNLOCKED])
+    def jsonrpc_wallet_encrypt(self, new_password, wallet_id=None):
+        """
+        Encrypt an unencrypted wallet with a password
+
+        Usage:
+            wallet_encrypt (<new_password> | --new_password=<new_password>)
+                            [--wallet_id=<wallet_id>]
+
+        Options:
+            --new_password=<new_password>  : (str) password to encrypt account
+            --wallet_id=<wallet_id>        : (str) restrict operation to specific wallet
+
+        Returns:
+            (bool) true if wallet is decrypted, otherwise false
+        """
+        wallet = self.wallet_manager.get_wallet_or_default(wallet_id)
+        return wallet.encrypt(new_password)
+
     @requires(WALLET_COMPONENT, conditions=[WALLET_IS_UNLOCKED])
     async def jsonrpc_wallet_send(
             self, amount, addresses, wallet_id=None,
@@ -1430,6 +1501,7 @@ class Daemon(metaclass=JSONRPCServerType):
 
         return account
 
+    @deprecated('wallet_unlock')
     @requires(WALLET_COMPONENT)
     def jsonrpc_account_unlock(self, password, account_id=None, wallet_id=None):
         """
@@ -1454,6 +1526,7 @@ class Daemon(metaclass=JSONRPCServerType):
             password, wallet.get_account_or_default(account_id)
         )
 
+    @deprecated('wallet_lock')
     @requires(WALLET_COMPONENT)
     def jsonrpc_account_lock(self, account_id=None, wallet_id=None):
         """
@@ -1474,6 +1547,7 @@ class Daemon(metaclass=JSONRPCServerType):
             wallet.get_account_or_default(account_id)
         )
 
+    @deprecated('wallet_decrypt')
     @requires(WALLET_COMPONENT, conditions=[WALLET_IS_UNLOCKED])
     def jsonrpc_account_decrypt(self, account_id=None, wallet_id=None):
         """
@@ -1494,6 +1568,7 @@ class Daemon(metaclass=JSONRPCServerType):
             wallet.get_account_or_default(account_id)
         )
 
+    @deprecated('wallet_encrypt')
     @requires(WALLET_COMPONENT, conditions=[WALLET_IS_UNLOCKED])
     def jsonrpc_account_encrypt(self, new_password, account_id=None, wallet_id=None):
         """

--- a/lbry/lbry/extras/daemon/Daemon.py
+++ b/lbry/lbry/extras/daemon/Daemon.py
@@ -1656,6 +1656,7 @@ class Daemon(metaclass=JSONRPCServerType):
                     for new_account in added_accounts:
                         asyncio.create_task(self.ledger.subscribe_account(new_account))
             wallet.save()
+            wallet.unlock(password)
         encrypted = wallet.pack(encrypt_password or password)
         return {
             'hash': self.jsonrpc_sync_hash(wallet_id),

--- a/lbry/tests/integration/test_sync.py
+++ b/lbry/tests/integration/test_sync.py
@@ -34,6 +34,12 @@ class WalletSynchronization(CommandTestCase):
 
         self.assertEqual(len((await daemon.jsonrpc_account_list())['lbc_regtest']), 1)
 
+        daemon2.jsonrpc_wallet_encrypt('password')
+        daemon2.jsonrpc_wallet_lock()
+        with self.assertRaises(AssertionError):
+            await daemon2.jsonrpc_sync_apply('password')
+
+        daemon2.jsonrpc_wallet_unlock('password')
         data = await daemon2.jsonrpc_sync_apply('password')
         await daemon.jsonrpc_sync_apply('password', data=data['data'], blocking=True)
 

--- a/torba/torba/client/wallet.py
+++ b/torba/torba/client/wallet.py
@@ -185,6 +185,7 @@ class Wallet:
     def lock(self):
         for account in self.accounts:
             if not account.encrypted:
+                assert account.password is not None, "account was never encrypted"
                 account.encrypt(account.password)
 
     @property
@@ -201,7 +202,7 @@ class Wallet:
 
     def encrypt(self, password):
         for account in self.accounts:
-            if not self.encrypted:
+            if not account.encrypted:
                 account.encrypt(password)
             account.serialize_encrypted = True
         self.save()

--- a/torba/torba/client/wallet.py
+++ b/torba/torba/client/wallet.py
@@ -170,6 +170,43 @@ class Wallet:
                 added_accounts.append(new_account)
         return added_accounts
 
+    @property
+    def is_locked(self) -> bool:
+        for account in self.accounts:
+            if account.encrypted:
+                return True
+        return False
+
+    def unlock(self, password):
+        for account in self.accounts:
+            if account.encrypted:
+                account.decrypt(password)
+
+    def lock(self):
+        for account in self.accounts:
+            if not account.encrypted:
+                account.encrypt(account.password)
+
+    @property
+    def is_encrypted(self) -> bool:
+        for account in self.accounts:
+            if account.serialize_encrypted:
+                return True
+        return False
+
+    def decrypt(self):
+        for account in self.accounts:
+            account.serialize_encrypted = False
+        self.save()
+
+    def encrypt(self, password):
+        for account in self.accounts:
+            if not self.encrypted:
+                account.encrypt(password)
+            account.serialize_encrypted = True
+        self.save()
+        self.unlock(password)
+
 
 class WalletStorage:
 

--- a/torba/torba/client/wallet.py
+++ b/torba/torba/client/wallet.py
@@ -181,12 +181,14 @@ class Wallet:
         for account in self.accounts:
             if account.encrypted:
                 account.decrypt(password)
+        return True
 
     def lock(self):
         for account in self.accounts:
             if not account.encrypted:
                 assert account.password is not None, "account was never encrypted"
                 account.encrypt(account.password)
+        return True
 
     @property
     def is_encrypted(self) -> bool:
@@ -199,6 +201,7 @@ class Wallet:
         for account in self.accounts:
             account.serialize_encrypted = False
         self.save()
+        return True
 
     def encrypt(self, password):
         for account in self.accounts:
@@ -207,6 +210,7 @@ class Wallet:
             account.serialize_encrypted = True
         self.save()
         self.unlock(password)
+        return True
 
 
 class WalletStorage:


### PR DESCRIPTION
backwards-incompatible: commands `account` `lock`/`unlock`/`encrypt`/`decrypt` have been replaced by `wallet` `lock`/`unlock`/`encrypt`/`decrypt`.