### PR TITLE
Improving error handling for null values

### DIFF
--- a/lbry/lbry/error/README.md
+++ b/lbry/lbry/error/README.md
@@ -33,6 +33,7 @@ Code | Name | Message
 105 | CommandPermanentlyUnavailable | Command '{command}' is permanently unavailable. -- such as when required component was intentionally configured not to start.
 **11x** | InputValue(ValueError) | Invalid argument value provided to command.
 111 | GenericInputValue | The value '{value}' for argument '{argument}' is not valid.
+112 | InputValueIsNone | None or null is not valid value for argument '{argument}'.
 **2xx** | Configuration | Configuration errors.
 201 | ConfigWrite | Cannot write configuration file '{path}'. -- When writing the default config fails on startup, such as due to permission issues.
 202 | ConfigRead | Cannot find provided configuration file '{path}'. -- Can't open the config file user provided via command line args.

--- a/lbry/lbry/error/__init__.py
+++ b/lbry/lbry/error/__init__.py
@@ -61,6 +61,12 @@ class GenericInputValueError(InputValueError):
         super().__init__(f"The value '{value}' for argument '{argument}' is not valid.")
 
 
+class InputValueIsNoneError(InputValueError):
+
+    def __init__(self, argument):
+        super().__init__(f"None or null is not valid value for argument '{argument}'.")
+
+
 class ConfigurationError(BaseError):
     """
     Configuration errors.

--- a/lbry/lbry/schema/claim.py
+++ b/lbry/lbry/schema/claim.py
@@ -124,7 +124,12 @@ class BaseClaim:
             for field in self.object_fields:
                 if key.startswith(f'{field}_'):
                     attr = getattr(self, field)
-                    setattr(attr, key[len(f'{field}_'):], kwargs.pop(key))
+
+                    attr_value = kwargs.pop(key)
+                    if attr_value is None:
+                        raise ValueError(f"Error updating claim - Null value provided for attribute {field}")
+                    
+                    setattr(attr, key[len(f'{field}_'):], attr_value)
                     continue
 
         for l in self.repeat_fields:

--- a/lbry/lbry/schema/claim.py
+++ b/lbry/lbry/schema/claim.py
@@ -215,7 +215,6 @@ class Stream(BaseClaim):
         return claim
 
     def update(self, file_path=None, height=None, width=None, duration=None, **kwargs):
-        self.none_check(kwargs)
 
         if kwargs.pop('clear_fee', False):
             self.message.ClearField('fee')
@@ -225,6 +224,8 @@ class Stream(BaseClaim):
                 kwargs.pop('fee_currency', None),
                 kwargs.pop('fee_amount', None)
             )
+
+        self.none_check(kwargs)
 
         if 'sd_hash' in kwargs:
             self.source.sd_hash = kwargs.pop('sd_hash')

--- a/lbry/tests/unit/schema/test_models.py
+++ b/lbry/tests/unit/schema/test_models.py
@@ -1,8 +1,8 @@
 from unittest import TestCase
-from unittest.mock import patch
 from decimal import Decimal
 
-from lbry.schema.claim import Claim, Stream, Collection, BaseClaim
+from lbry.schema.claim import Claim, Stream, Collection
+from lbry.error import InputValueIsNoneError
 
 
 class TestClaimContainerAwareness(TestCase):
@@ -198,19 +198,22 @@ class TestLocations(TestCase):
         self.assertEqual(stream.locations[0].country, 'UA')
 
 
-class TestBaseClaimUpdates(TestCase):
+class TestStreamUpdating(TestCase):
 
-    @patch('lbry.schema.claim.Claim')
-    def test_claim_update_url_ok(self, MockClaim):
-        # test if an attribute is provided correctly
-        base_claim = BaseClaim(MockClaim)
-        base_claim.update(thumbnail_url="somescheme:some/path")
-        self.assertEqual(base_claim.thumbnail.url, "somescheme:some/path")
-
-    @patch('lbry.schema.claim.Claim')
-    def test_claim_update_url_error(self, MockClaim):
-        # test if an attribute is null
-        base_claim = BaseClaim(MockClaim)
-        with self.assertRaisesRegex(ValueError, "Error updating claim - Null value provided for attribute thumbnail"):
-            base_claim.update(thumbnail_url=None)
-
+    def test_stream_update(self):
+        stream = Stream()
+        # each of these values is set differently inside of .update()
+        stream.update(
+            title="foo",
+            thumbnail_url="somescheme:some/path",
+            file_name="file-name"
+        )
+        self.assertEqual(stream.title, "foo")
+        self.assertEqual(stream.thumbnail.url, "somescheme:some/path")
+        self.assertEqual(stream.source.name, "file-name")
+        with self.assertRaises(InputValueIsNoneError):
+            stream.update(title=None)
+        with self.assertRaises(InputValueIsNoneError):
+            stream.update(file_name=None)
+        with self.assertRaises(InputValueIsNoneError):
+            stream.update(thumbnail_url=None)

--- a/lbry/tests/unit/schema/test_models.py
+++ b/lbry/tests/unit/schema/test_models.py
@@ -1,7 +1,8 @@
 from unittest import TestCase
+from unittest.mock import patch
 from decimal import Decimal
 
-from lbry.schema.claim import Claim, Stream, Collection
+from lbry.schema.claim import Claim, Stream, Collection, BaseClaim
 
 
 class TestClaimContainerAwareness(TestCase):
@@ -195,3 +196,21 @@ class TestLocations(TestCase):
         stream = Stream()
         stream.locations.append({"country": "UA"})
         self.assertEqual(stream.locations[0].country, 'UA')
+
+
+class TestBaseClaimUpdates(TestCase):
+
+    @patch('lbry.schema.claim.Claim')
+    def test_claim_update_url_ok(self, MockClaim):
+        # test if an attribute is provided correctly
+        base_claim = BaseClaim(MockClaim)
+        base_claim.update(thumbnail_url="somescheme:some/path")
+        self.assertEqual(base_claim.thumbnail.url, "somescheme:some/path")
+
+    @patch('lbry.schema.claim.Claim')
+    def test_claim_update_url_error(self, MockClaim):
+        # test if an attribute is null
+        base_claim = BaseClaim(MockClaim)
+        with self.assertRaisesRegex(ValueError, "Error updating claim - Null value provided for attribute thumbnail"):
+            base_claim.update(thumbnail_url=None)
+


### PR DESCRIPTION
Addressing issue #2441 - I saw your Hacktoberfest post and thought I'd try and contribute. This issue wasn't specifically tagged with the Hacktoberfest label, but it seemed like one I could help with. I added null checking for the attributes with a clearer error message, and unit tests to verify.