### PR TITLE
update trending period

### DIFF
--- a/lbry/lbry/wallet/server/db/trending.py
+++ b/lbry/lbry/wallet/server/db/trending.py
@@ -5,7 +5,7 @@ TRENDING_WINDOW = 134
 
 # TRENDING_DATA_POINTS says how many samples to use for the trending algorithm
 # i.e. only consider claims from the most recent (TRENDING_WINDOW * TRENDING_DATA_POINTS) blocks
-TRENDING_DATA_POINTS = 7
+TRENDING_DATA_POINTS = 28
 
 CREATE_TREND_TABLE = """
     create table if not exists trend (

--- a/lbry/lbry/wallet/server/db/writer.py
+++ b/lbry/lbry/wallet/server/db/writer.py
@@ -122,6 +122,7 @@ class SQLDB:
         create unique index if not exists claim_effective_amount_idx on claim (effective_amount, claim_hash, release_time);
         create unique index if not exists claim_release_time_idx on claim (release_time, claim_hash);
         create unique index if not exists claim_trending_global_mixed_idx on claim (trending_global, trending_mixed, claim_hash);
+        create unique index if not exists claim_trending_group_mixed_idx on claim (trending_group, trending_mixed, claim_hash);
         create unique index if not exists filter_fee_amount_order_release_time_idx on claim (fee_amount, release_time, claim_hash);
 
         create unique index if not exists claim_type_trending_idx on claim (claim_type, trending_global, trending_mixed, claim_hash);


### PR DESCRIPTION
This gets us back to ~7 days, which was originally requested as part of this change.

Will won't require a resync, we'll just start collecting 7 days from the time it's deployed. 