### PR TITLE
full text search in wallet server using `claim_search` via argument `--text`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-dist: xenial
+dist: bionic
 language: python
 python: "3.7"
 

--- a/lbry/lbry/extras/daemon/Daemon.py
+++ b/lbry/lbry/extras/daemon/Daemon.py
@@ -2094,7 +2094,7 @@ class Daemon(metaclass=JSONRPCServerType):
         eg. --height=">400000" would limit results to only claims above 400k block height.
 
         Usage:
-            claim_search [<name> | --name=<name>] [--txid=<txid>] [--nout=<nout>]
+            claim_search [<name> | --name=<name>] [--text=<text>] [--txid=<txid>] [--nout=<nout>]
                          [--claim_id=<claim_id> | --claim_ids=<claim_ids>...]
                          [--channel=<channel> |
                              [[--channel_ids=<channel_ids>...] [--not_channel_ids=<not_channel_ids>...]]]
@@ -2119,6 +2119,7 @@ class Daemon(metaclass=JSONRPCServerType):
 
         Options:
             --name=<name>                   : (str) claim name (normalized)
+            --text=<text>                   : (str) full text search
             --claim_id=<claim_id>           : (str) full or partial claim id
             --claim_ids=<claim_ids>         : (list) list of full claim ids
             --txid=<txid>                   : (str) transaction id

--- a/lbry/lbry/wallet/server/db/full_text_search.py
+++ b/lbry/lbry/wallet/server/db/full_text_search.py
@@ -22,7 +22,7 @@ def fts_action_sql(claims=None, action='insert'):
         'tags': "(select group_concat(tag, ' ') from tag where tag.claim_hash=claim.claim_hash)"
     }
     if action == 'delete':
-        select['search'] = 'delete'
+        select['search'] = '"delete"'
 
     where, values = "", {}
     if claims:

--- a/lbry/lbry/wallet/server/db/full_text_search.py
+++ b/lbry/lbry/wallet/server/db/full_text_search.py
@@ -1,0 +1,53 @@
+import sqlite3
+from torba.client.basedatabase import constraints_to_sql
+
+CREATE_FULL_TEXT_SEARCH = """
+create virtual table if not exists search using fts5(
+    claim_name, channel_name, title, description, author, tags,
+    content=claim, tokenize=porter
+);
+"""
+
+FTS_ORDER_BY = "bm25(search, 4.0, 8.0, 1.0, 0.5, 1.0, 0.5)"
+
+
+def fts_action_sql(claims=None, action='insert'):
+    select = {
+        'rowid': "claim.rowid",
+        'claim_name': "claim.normalized",
+        'channel_name': "channel.normalized",
+        'title': "claim.title",
+        'description': "claim.description",
+        'author': "claim.author",
+        'tags': "(select group_concat(tag, ' ') from tag where tag.claim_hash=claim.claim_hash)"
+    }
+    if action == 'delete':
+        select['search'] = 'delete'
+
+    where, values = "", {}
+    if claims:
+        where, values = constraints_to_sql({
+            'claim.claim_hash__in': [sqlite3.Binary(claim_hash) for claim_hash in claims]
+        })
+        where = 'WHERE '+where
+
+    return f"""
+        INSERT INTO search ({','.join(select.keys())})
+        SELECT {','.join(select.values())} FROM claim
+            LEFT JOIN claim as channel ON (claim.channel_hash=channel.claim_hash) {where}
+    """, values
+
+
+def update_full_text_search(action, outputs, db, height, final_height, is_first_sync):
+    if is_first_sync:
+        if height == final_height:
+            db.execute(*fts_action_sql())
+        return
+    if not outputs:
+        return
+    if action in ("before-delete", "before-update"):
+        db.execute(*fts_action_sql(outputs, 'delete'))
+    elif action in ("after-insert", "after-update"):
+        db.execute(*fts_action_sql(outputs, 'insert'))
+    else:
+        raise ValueError(f"Invalid action for updating full text search: '{action}'")

--- a/lbry/tests/integration/test_claim_commands.py
+++ b/lbry/tests/integration/test_claim_commands.py
@@ -328,6 +328,38 @@ class ClaimSearchCommand(ClaimTestCase):
         await self.assertFindsClaims([image], media_types=['image/png'])
         await self.assertFindsClaims([image, video], media_types=['video/mp4', 'image/png'])
 
+    async def test_search_by_text(self):
+        chan1_id = self.get_claim_id(await self.channel_create('@SatoshiNakamoto'))
+        chan2_id = self.get_claim_id(await self.channel_create('@Bitcoin'))
+        chan3_id = self.get_claim_id(await self.channel_create('@IAmSatoshi'))
+
+        claim1 = await self.stream_create(
+            "the-real-satoshi", title="The Real Satoshi Nakamoto",
+            description="Documentary about the real Satoshi Nakamoto, creator of bitcoin.",
+            tags=['satoshi nakamoto', 'bitcoin', 'documentary']
+        )
+        claim2 = await self.stream_create(
+            "about-me", channel_id=chan1_id, title="Satoshi Nakamoto Autobiography",
+            description="I am Satoshi Nakamoto and this is my autobiography.",
+            tags=['satoshi nakamoto', 'bitcoin', 'documentary', 'autobiography']
+        )
+        claim3 = await self.stream_create(
+            "history-of-bitcoin", channel_id=chan2_id, title="History of Bitcoin",
+            description="History of bitcoin and its creator Satoshi Nakamoto.",
+            tags=['satoshi nakamoto', 'bitcoin', 'documentary', 'history']
+        )
+        claim4 = await self.stream_create(
+            "satoshi-conspiracies", channel_id=chan3_id, title="Satoshi Nakamoto Conspiracies",
+            description="Documentary detailing various conspiracies surrounding Satoshi Nakamoto.",
+            tags=['conspiracies', 'bitcoin', 'satoshi nakamoto']
+        )
+
+        await self.assertFindsClaims([], text='cheese')
+        await self.assertFindsClaims([claim3], text='history')
+        await self.assertFindsClaims([claim4], text='conspiracy')
+        await self.assertFindsClaims([claim1, claim4, claim2, claim3], text='documentary')
+        await self.assertFindsClaims([claim4, claim1, claim2, claim3], text='satoshi')
+
 
 class ChannelCommands(CommandTestCase):
 

--- a/lbry/tests/integration/test_claim_commands.py
+++ b/lbry/tests/integration/test_claim_commands.py
@@ -355,10 +355,24 @@ class ClaimSearchCommand(ClaimTestCase):
         )
 
         await self.assertFindsClaims([], text='cheese')
+        await self.assertFindsClaims([claim2], text='autobiography')
         await self.assertFindsClaims([claim3], text='history')
         await self.assertFindsClaims([claim4], text='conspiracy')
+        await self.assertFindsClaims([], text='conspiracy AND history')
+        await self.assertFindsClaims([claim4, claim3], text='conspiracy OR history')
         await self.assertFindsClaims([claim1, claim4, claim2, claim3], text='documentary')
         await self.assertFindsClaims([claim4, claim1, claim2, claim3], text='satoshi')
+
+        claim2 = await self.stream_update(
+            self.get_claim_id(claim2), clear_tags=True, tags=['cloud'],
+            title="Satoshi Nakamoto Nography",
+            description="I am Satoshi Nakamoto and this is my nography.",
+        )
+        await self.assertFindsClaims([], text='autobiography')
+        await self.assertFindsClaims([claim2], text='cloud')
+
+        await self.stream_abandon(self.get_claim_id(claim2))
+        await self.assertFindsClaims([], text='cloud')
 
 
 class ChannelCommands(CommandTestCase):


### PR DESCRIPTION
release-text: Wallet server now supports full text searching by using `claim_search` command and passing `--text` argument (note that `--order_by` is ignored when `--text` is passed because it will sort results based on text match ranking).