### PR TITLE
bump protocol version

### DIFF
--- a/lbry/lbry/wallet/network.py
+++ b/lbry/lbry/wallet/network.py
@@ -2,6 +2,7 @@ from torba.client.basenetwork import BaseNetwork
 
 
 class Network(BaseNetwork):
+    PROTOCOL_VERSION = '2.0'
 
     def get_claims_by_ids(self, claim_ids):
         return self.rpc('blockchain.claimtrie.getclaimsbyids', claim_ids)

--- a/lbry/lbry/wallet/server/session.py
+++ b/lbry/lbry/wallet/server/session.py
@@ -95,7 +95,8 @@ class LBRYSessionManager(SessionManager):
 
 
 class LBRYElectrumX(ElectrumX):
-    PROTOCOL_MIN = (0, 0)  # temporary, for supporting 0.10 protocol
+    PROTOCOL_MIN = (2, 0)  # v0.48 is backwards incompatible, forking a new protocol
+    PROTOCOL_MAX = (2, 0)
     max_errors = math.inf  # don't disconnect people for errors! let them happen...
     session_mgr: LBRYSessionManager
     version = sdk_version
@@ -111,7 +112,7 @@ class LBRYElectrumX(ElectrumX):
         self.filtering_channels_ids = list(filter(None, filtering_channels.split(' ')))
 
     def set_request_handlers(self, ptuple):
-        super().set_request_handlers(ptuple)
+        super().set_request_handlers((1, 2) if ptuple == (2, 0) else ptuple)  # our "2.0" is electrumx 1.2
         handlers = {
             'blockchain.transaction.get_height': self.transaction_get_height,
             'blockchain.claimtrie.search': self.claimtrie_search,

--- a/torba/torba/client/basenetwork.py
+++ b/torba/torba/client/basenetwork.py
@@ -13,8 +13,6 @@ log = logging.getLogger(__name__)
 
 
 class ClientSession(BaseClientSession):
-    PROTOCOL_VERSION = '2.0'
-
     def __init__(self, *args, network, server, timeout=30, on_connect_callback=None, **kwargs):
         self.network = network
         self.server = server
@@ -119,9 +117,9 @@ class ClientSession(BaseClientSession):
                 self.trigger_urgent_reconnect.clear()
 
     async def ensure_server_version(self, required=None, timeout=3):
+        required = required or self.network.PROTOCOL_VERSION
         return await asyncio.wait_for(
-            self.send_request(
-                'server.version', [__version__, required or self.PROTOCOL_VERSION]), timeout=timeout
+            self.send_request('server.version', [__version__, required]), timeout=timeout
         )
 
     async def create_connection(self, timeout=6):
@@ -145,6 +143,7 @@ class ClientSession(BaseClientSession):
 
 
 class BaseNetwork:
+    PROTOCOL_VERSION = '1.2'
 
     def __init__(self, ledger):
         self.config = ledger.config


### PR DESCRIPTION
backwards-incompatible: This release includes backwards incompatible APIs and will automatically disconnect clients with an older version when they try to connect.