### PR TITLE
Autoregressive trending quantities in claim table of claims.db

### DIFF
--- a/lbry/lbry/wallet/server/db/trending.py
+++ b/lbry/lbry/wallet/server/db/trending.py
@@ -61,7 +61,8 @@ class ZScore:
 
     @property
     def standard_deviation(self):
-        return sqrt((self.power / self.count) - self.mean ** 2)
+        value = (self.power / self.count) - self.mean ** 2
+        return sqrt(value) if value > 0 else 0
 
     def finalize(self):
         if self.count == 0:

--- a/lbry/lbry/wallet/server/db/trending.py
+++ b/lbry/lbry/wallet/server/db/trending.py
@@ -130,7 +130,7 @@ def calculate_trending(db, height, final_height):
                 end="", flush=True)
     db.execute(f"""
     UPDATE claim SET
-        trending_ar_y = decay(trending_ar_y) -- + soften(amount + support_amount) - soften(old_total_amount);
+        trending_ar_y = decay(trending_ar_y) + soften(amount + support_amount) - soften(old_total_amount);
     """)
     db.execute(f"""
     UPDATE claim SET

--- a/lbry/lbry/wallet/server/db/writer.py
+++ b/lbry/lbry/wallet/server/db/writer.py
@@ -84,7 +84,10 @@ class SQLDB:
             trending_group integer not null default 0,
             trending_mixed integer not null default 0,
             trending_local integer not null default 0,
-            trending_global integer not null default 0
+            trending_global integer not null default 0,
+            trending_ar_y integer not null default 1.0E-6,
+            trending_ar_final integer not null default 1.0E-6,
+            old_total_amount integer not null default 1
         );
 
         create index if not exists claim_normalized_idx on claim (normalized, activation_height);


### PR DESCRIPTION
First attempt at calculating a different trending quantity in the wallet server. The resulting column for ranking claims is `trending_ar_final`.

The standard trending columns and tables are still there but I've commented out their computation, as this is just for testing. There are a few tweakable parameters but let's not worry about their values for n ow.

The trending scores are updated every 134th block and the update takes about 15 seconds on my current low to mid end laptop (with SSD). Optimisations are surely possible but I haven't done them. 

The only files I edited are trending.py and writer.py. In the latter, I've declared the new columns as integers even though they contain reals, because I didn't want to mess up the list of integer columns in that file.