### PR TITLE
Fix blob request loop

### DIFF
--- a/lbry/lbry/blob/blob_file.py
+++ b/lbry/lbry/blob/blob_file.py
@@ -163,7 +163,10 @@ class AbstractBlob:
         if not self.is_readable():
             raise OSError('blob files cannot be read')
         with self.reader_context() as handle:
-            return await self.loop.sendfile(writer.transport, handle, count=self.get_length())
+            try:
+                return await self.loop.sendfile(writer.transport, handle, count=self.get_length())
+            except (ConnectionResetError, BrokenPipeError, RuntimeError, OSError, AttributeError):
+                return -1
 
     def decrypt(self, key: bytes, iv: bytes) -> bytes:
         """


### PR DESCRIPTION
backwards-incompatible: This release changes the behavior of downloads that fail to complete. Previously they would be re-attempted automatically. As of this release, download attempts that stop due to all of the blobs not being available will go into a `stopped` state and must be resumed with `file_set_status`, `get`, or `file_save`, or by reading via partial content requests to complete the download (if possible).