### PR TITLE
disconnect from server that returns rpc error for server.version

### DIFF
--- a/lbry/wallet/network.py
+++ b/lbry/wallet/network.py
@@ -98,6 +98,7 @@ class ClientSession(BaseClientSession):
                     await self.ensure_server_version()
                 retry_delay = default_delay
             except RPCError as e:
+                await self.close()
                 log.debug("Server error, ignoring for 1h: %s:%d -- %s", *self.server, e.message)
                 retry_delay = 60 * 60
             except IncompatibleWalletServerError:


### PR DESCRIPTION
In https://github.com/lbryio/lbry-sdk/pull/2728 the client disconnects when it thinks the server is incompatible. This fixes the case where the server returns an error due to it believing the client is incompatible. In both cases the server version is rechecked hourly to see if it becomes compatible.