### PR TITLE
fixed some issues with AR trending

### DIFF
--- a/lbry/wallet/server/db/trending/ar.py
+++ b/lbry/wallet/server/db/trending/ar.py
@@ -31,7 +31,7 @@ def install(connection):
     check_trending_values(connection)
 
     if TRENDING_LOG:
-        f = open("trending_ar.log", "w")
+        f = open("trending_ar.log", "a")
         f.close()
 
 # Stub
@@ -61,7 +61,6 @@ def check_trending_values(connection):
         print("done.")
 
 
-
 def spike_height(trending_score, x, x_old, time_boost=1.0):
     """
     Compute the size of a trending spike.
@@ -76,8 +75,9 @@ def spike_height(trending_score, x, x_old, time_boost=1.0):
 
     # Softened change in amount counts more for minnows
     if delta > 0.0:
-        multiplier = 1.0/math.sqrt(x + 1.0)
-        softened_change_in_amount *= multiplier
+        if trending_score >= 0.0:
+            multiplier = 0.1/((trending_score/time_boost + softened_change_in_amount) + 1.0)
+            softened_change_in_amount *= multiplier
     else:
         softened_change_in_amount *= -1.0
 

--- a/lbry/wallet/server/db/trending/ar.py
+++ b/lbry/wallet/server/db/trending/ar.py
@@ -28,6 +28,11 @@ TRENDING_LOG = True
 def install(connection):
     check_trending_values(connection)
 
+    if TRENDING_LOG:
+        f = open("trending_ar.log", "w")
+        f.close()
+
+
 CREATE_TREND_TABLE = ""
 
 
@@ -53,8 +58,6 @@ def check_trending_values(connection):
                       COMMIT;""")
         print("done.")
 
-    # Create the index
-    c.execute("create index if not exists claim_id_only_idx on claim (claim_id);")
 
 
 def spike_height(trending_score, x, x_old, time_boost=1.0):
@@ -170,8 +173,6 @@ def test_trending():
 # One global instance
 # pylint: disable=C0103
 trending_data = TrendingData()
-f = open("trending_ar.log", "w")
-f.close()
 
 def run(db, height, final_height, recalculate_claim_hashes):
 

--- a/lbry/wallet/server/db/trending/ar.py
+++ b/lbry/wallet/server/db/trending/ar.py
@@ -114,8 +114,8 @@ class TrendingData:
     def insert_claim_from_load(self, claim_hash, trending_score, total_amount):
         assert not self.initialised
         self.claims[claim_hash] = {"trending_score": trending_score,
-                                 "total_amount": total_amount,
-                                 "changed": False}
+                                   "total_amount": total_amount,
+                                   "changed": False}
 
 
     def update_claim(self, claim_hash, total_amount, time_boost=1.0):


### PR DESCRIPTION
* The `trending_ar.log` file is only created if `install` is called
* Skip trending calculations except for most recent 5*HALF_LIFE = 670 blocks to speed up initial sync (this was always the intent but was broken).
* Use claim_hash instead of claim_id to identify claims
* No claim_id index required.

The changes are quite simple but I am still testing them.