### PR TITLE
update cffi to v1.13.2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ setup(
         'colorama==0.3.7',
         'distro==1.4.0',
         'base58==1.0.0',
-        'cffi==1.12.1',
+        'cffi==1.13.2',
         'cryptography==2.5',
         'protobuf==3.6.1',
         'msgpack==0.6.1',


### PR DESCRIPTION
This fixes some compilation issues for CPython 3.8+ that I was having while running `make install`

```
Running setup.py install for cffi ... error
ERROR: Command errored out with exit status 1:
 command: /home/mk/.pyenv/versions/3.8.1/bin/python3.8 -u -c 'import sys, setuptools, tokenize; sys.argv[0] = '"'"'/tmp/pip-install-b0snfbt_/cffi/setup.py'"'"'; __file__='"'"'/tmp/pip-install-b0snfbt_/cffi/setup.py'"'"';f=getattr(tokenize, '"'"'open'"'"', open)(__file__);code=f.read().replace('"'"'\r\n'"'"', '"'"'\n'"'"');f.close();exec(compile(code, __file__, '"'"'exec'"'"'))' install --record /tmp/pip-record-sv6iwie5/install-record.txt --single-version-externally-managed --compile --install-headers /home/mk/.pyenv/versions/3.8.1/include/python3.8/cffi
     cwd: /tmp/pip-install-b0snfbt_/cffi/
Complete output (38 lines):
running install
running build
running build_py
creating build
creating build/lib.linux-x86_64-3.8
creating build/lib.linux-x86_64-3.8/cffi
copying cffi/recompiler.py -> build/lib.linux-x86_64-3.8/cffi
copying cffi/verifier.py -> build/lib.linux-x86_64-3.8/cffi
copying cffi/cffi_opcode.py -> build/lib.linux-x86_64-3.8/cffi
copying cffi/setuptools_ext.py -> build/lib.linux-x86_64-3.8/cffi
copying cffi/__init__.py -> build/lib.linux-x86_64-3.8/cffi
copying cffi/lock.py -> build/lib.linux-x86_64-3.8/cffi
copying cffi/api.py -> build/lib.linux-x86_64-3.8/cffi
copying cffi/vengine_gen.py -> build/lib.linux-x86_64-3.8/cffi
copying cffi/pkgconfig.py -> build/lib.linux-x86_64-3.8/cffi
copying cffi/ffiplatform.py -> build/lib.linux-x86_64-3.8/cffi
copying cffi/cparser.py -> build/lib.linux-x86_64-3.8/cffi
copying cffi/backend_ctypes.py -> build/lib.linux-x86_64-3.8/cffi
copying cffi/error.py -> build/lib.linux-x86_64-3.8/cffi
copying cffi/commontypes.py -> build/lib.linux-x86_64-3.8/cffi
copying cffi/model.py -> build/lib.linux-x86_64-3.8/cffi
copying cffi/vengine_cpy.py -> build/lib.linux-x86_64-3.8/cffi
copying cffi/_cffi_include.h -> build/lib.linux-x86_64-3.8/cffi
copying cffi/parse_c_type.h -> build/lib.linux-x86_64-3.8/cffi
copying cffi/_embedding.h -> build/lib.linux-x86_64-3.8/cffi
copying cffi/_cffi_errors.h -> build/lib.linux-x86_64-3.8/cffi
running build_ext
building '_cffi_backend' extension
creating build/temp.linux-x86_64-3.8
creating build/temp.linux-x86_64-3.8/c
gcc -pthread -Wno-unused-result -Wsign-compare -DNDEBUG -g -fwrapv -O3 -Wall -fPIC -DUSE__THREAD -DHAVE_SYNC_SYNCHRONIZE -I/usr/lib/libffi-3.2.1/include -I/home/mk/.pyenv/versions/3.8.1/include/python3.8 -c c/_cffi_backend.c -o build/temp.linux-x86_64-3.8/c/_cffi_backend.o
In file included from c/cffi1_module.c:20,
                 from c/_cffi_backend.c:7552:
c/call_python.c: In function ‘_get_interpstate_dict’:
c/call_python.c:20:30: error: dereferencing pointer to incomplete type ‘PyInterpreterState’ {aka ‘struct _is’}
   20 |     builtins = tstate->interp->builtins;
      |                              ^~
error: command 'gcc' failed with exit status 1
----------------------------------------

```

The relevant fixes are available in cffi v1.12.3 but I figured it'd be worth moving to v1.13 [as I don't see any breaking changes.](https://cffi.readthedocs.io/en/latest/whatsnew.html#v1-13-2)

I haven't looked at updates for any of the other dependencies as they install fine.