### PR TITLE
removes ability to comment anonymously

### DIFF
--- a/scripts/generate_json_api.py
+++ b/scripts/generate_json_api.py
@@ -333,7 +333,7 @@ class Examples(CommandTestCase):
         )
 
         reply = await r(
-            'You can r',
+            'Use the parent_id param to make replies',
             'comment', 'create',
             '--comment="I have photographic evidence confirming Sasquatch exists"',
             f'--channel_name=@channel', f'--parent_id={comment["comment_id"]}'


### PR DESCRIPTION
Changes the `channel_name`/`channel_id` parameters on the `comment_create` command from being optional to required.

Addresses #2799 