### PR TITLE
when using `--resolve` with local claim `*_list` commands, update resolved result with local metadata (such as `is_mine`)

### DIFF
--- a/lbry/wallet/ledger.py
+++ b/lbry/wallet/ledger.py
@@ -739,6 +739,7 @@ class Ledger(metaclass=LedgerRegistry):
         for txo in txos:
             resolved = response[txo.permanent_url]
             if isinstance(resolved, Output):
+                resolved.update_annotations(txo)
                 results.append(resolved)
             else:
                 if isinstance(resolved, dict) and 'error' in resolved:

--- a/tests/integration/blockchain/test_claim_commands.py
+++ b/tests/integration/blockchain/test_claim_commands.py
@@ -488,6 +488,9 @@ class ClaimCommands(ClaimTestCase):
         self.assertTrue(r[0]['meta']['is_controlling'])
         self.assertTrue(r[1]['meta']['is_controlling'])
 
+        # check that metadata is transfered
+        self.assertTrue(r[0]['is_mine'])
+
 
 class ChannelCommands(CommandTestCase):
 


### PR DESCRIPTION
fixes #2833