### PR TITLE
revert LD_LIBRARY_PATH before calling ffmpeg

### DIFF
--- a/lbry/file_analysis.py
+++ b/lbry/file_analysis.py
@@ -7,6 +7,8 @@ import re
 import shlex
 import shutil
 import platform
+
+import lbry.utils
 from lbry.conf import TranscodeConfig
 
 log = logging.getLogger(__name__)
@@ -28,7 +30,9 @@ class VideoFileAnalyzer:
         self._which = None
         self._checked_ffmpeg = False
         self._env_copy = dict(os.environ)
-        self._replace_or_pop_env('LD_LIBRARY_PATH')
+        if lbry.utils.is_running_from_bundle():
+            # handle the situation where PyInstaller overrides our runtime environment:
+            self._replace_or_pop_env('LD_LIBRARY_PATH')
 
     async def _execute(self, command, arguments):
         if DISABLED:

--- a/lbry/file_analysis.py
+++ b/lbry/file_analysis.py
@@ -37,10 +37,10 @@ class VideoFileAnalyzer:
         try:
             version, code = await self._execute(name, "-version")
         except Exception as e:
-            log.warning("Unable to run %s, but it was requested. Message: %s", name, str(e))
             code = -1
-            version = ""
+            version = str(e)
         if code != 0 or not version.startswith(name):
+            log.warning("Unable to run %s, but it was requested. Code: %d; Message: %s", name, code, version)
             raise FileNotFoundError(f"Unable to locate or run {name}. Please install FFmpeg "
                                     f"and ensure that it is callable via PATH or conf.ffmpeg_folder")
         return version

--- a/lbry/utils.py
+++ b/lbry/utils.py
@@ -4,6 +4,7 @@ import datetime
 import random
 import socket
 import string
+import sys
 import json
 import typing
 import asyncio
@@ -276,3 +277,8 @@ async def get_external_ip() -> typing.Optional[str]:  # used if upnp is disabled
                 return response['data']['ip']
     except Exception:
         return
+
+
+def is_running_from_bundle():
+    # see https://pyinstaller.readthedocs.io/en/stable/runtime-information.html
+    return getattr(sys, 'frozen', False) and hasattr(sys, '_MEIPASS')

--- a/tests/integration/other/test_transcoding.py
+++ b/tests/integration/other/test_transcoding.py
@@ -93,6 +93,11 @@ class TranscodeValidation(ClaimTestCase):
         fixed_file = await self.analyzer.verify_or_repair(True, True, file_name)
         pathlib.Path(fixed_file).unlink()
 
+    async def test_max_bit_rate(self):
+        self.conf.video_bitrate_maximum = 100
+        with self.assertRaisesRegex(Exception, "The bit rate is above the configured maximum"):
+            await self.analyzer.verify_or_repair(True, False, self.video_file_name)
+
     async def test_video_format(self):
         file_name = self.make_name("bad_video_format_1")
         if not file_name.exists():


### PR DESCRIPTION
PyInstaller modifies the LD_LIBRARY_PATH variable. This affects the execution of files external to the package. It was affecting the execution of ffmpeg but is handled here as suggested in the documentation at https://pyinstaller.readthedocs.io/en/stable/runtime-information.html#ld-library-path-libpath-considerations

Fixes #2838 