### PR TITLE
fix DHT setup and disable ffmpeg on windows temporarily

### DIFF
--- a/lbry/extras/cli.py
+++ b/lbry/extras/cli.py
@@ -3,7 +3,6 @@ import sys
 import shutil
 import signal
 import pathlib
-import platform
 import json
 import asyncio
 import argparse
@@ -262,9 +261,6 @@ def setup_logging(logger: logging.Logger, args: argparse.Namespace, conf: Config
 
 
 def run_daemon(args: argparse.Namespace, conf: Config):
-    if sys.version_info < (3, 8) and platform.system() == "Windows":
-        # TODO: remove after we move to requiring Python 3.8
-        asyncio.set_event_loop(asyncio.ProactorEventLoop())
     loop = asyncio.get_event_loop()
     if args.verbose is not None:
         loop.set_debug(True)

--- a/lbry/file_analysis.py
+++ b/lbry/file_analysis.py
@@ -6,10 +6,11 @@ import pathlib
 import re
 import shlex
 import shutil
-
+import platform
 from lbry.conf import TranscodeConfig
 
 log = logging.getLogger(__name__)
+DISABLED = platform.system() == "Windows"
 
 
 class VideoFileAnalyzer:
@@ -22,6 +23,8 @@ class VideoFileAnalyzer:
         self._checked_ffmpeg = False
 
     async def _execute(self, command, arguments):
+        if DISABLED:
+            return "Disabled on Windows", -1
         args = shlex.split(arguments)
         process = await asyncio.create_subprocess_exec(
             os.path.join(self._conf.ffmpeg_folder, command), *args,


### PR DESCRIPTION
This is a band-aid until `asyncio.create_subprocess_exec` can be replaced with `subprocess` to avoid ProactorEventLoop breaking UDP protocols on windows.