### PR TITLE
added new `txo_list` command with filtering for `--claim_id`, claim `--name` and `--is_received`/`--is_not_received`, also commands `claim_list`/`stream_list`/`channel_list`/`support_list` are based on `txo_list` and thus support most of the new filters

### DIFF
--- a/lbry/extras/daemon/daemon.py
+++ b/lbry/extras/daemon/daemon.py
@@ -21,9 +21,10 @@ from prometheus_client import generate_latest as prom_generate_latest
 from google.protobuf.message import DecodeError
 from lbry.wallet import (
     Wallet, ENCRYPT_ON_DISK, SingleKey, HierarchicalDeterministic,
-    Transaction, Output, Input, Account
+    Transaction, Output, Input, Account, database
 )
 from lbry.wallet.dewies import dewies_to_lbc, lbc_to_dewies, dict_values_to_lbc
+from lbry.wallet.constants import TXO_TYPES, CLAIM_TYPE_NAMES
 
 from lbry import utils
 from lbry.conf import Config, Setting, NOT_SET
@@ -2167,19 +2168,20 @@ class Daemon(metaclass=JSONRPCServerType):
     """
 
     @requires(WALLET_COMPONENT)
-    def jsonrpc_claim_list(
-            self, claim_type=None, account_id=None, wallet_id=None, page=None, page_size=None, resolve=False):
+    def jsonrpc_claim_list(self, claim_type=None, **kwargs):
         """
         List my stream and channel claims.
 
         Usage:
-            claim_list [--claim_type=<claim_type>...]
+            claim_list [--claim_type=<claim_type>...] [--claim_id=<claim_id>...] [--name=<name>...]
                        [--account_id=<account_id>] [--wallet_id=<wallet_id>]
                        [--page=<page>] [--page_size=<page_size>]
                        [--resolve]
 
         Options:
-            --claim_type=<claim_type>  : (str) claim type: channel, stream, repost, collection
+            --claim_type=<claim_type>  : (str or list) claim type: channel, stream, repost, collection
+            --claim_id=<claim_id>      : (str or list) claim id
+            --name=<name>              : (str or list) claim name
             --account_id=<account_id>  : (str) id of the account to query
             --wallet_id=<wallet_id>    : (str) restrict results to specific wallet
             --page=<page>              : (int) page to return during paginating
@@ -2188,15 +2190,9 @@ class Daemon(metaclass=JSONRPCServerType):
 
         Returns: {Paginated[Output]}
         """
-        wallet = self.wallet_manager.get_wallet_or_default(wallet_id)
-        if account_id:
-            account = wallet.get_account_or_error(account_id)
-            claims = account.get_claims
-            claim_count = account.get_claim_count
-        else:
-            claims = partial(self.ledger.get_claims, wallet=wallet, accounts=wallet.accounts)
-            claim_count = partial(self.ledger.get_claim_count, wallet=wallet, accounts=wallet.accounts)
-        return paginate_rows(claims, claim_count, page, page_size, claim_type=claim_type, resolve=resolve)
+        kwargs['type'] = claim_type or CLAIM_TYPE_NAMES
+        kwargs['unspent'] = True
+        return self.jsonrpc_txo_list(**kwargs)
 
     @requires(WALLET_COMPONENT)
     async def jsonrpc_claim_search(self, **kwargs):
@@ -2699,15 +2695,18 @@ class Daemon(metaclass=JSONRPCServerType):
         return tx
 
     @requires(WALLET_COMPONENT)
-    def jsonrpc_channel_list(self, account_id=None, wallet_id=None, page=None, page_size=None, resolve=False):
+    def jsonrpc_channel_list(self, *args, **kwargs):
         """
         List my channel claims.
 
         Usage:
             channel_list [<account_id> | --account_id=<account_id>] [--wallet_id=<wallet_id>]
+                         [--name=<name>...] [--claim_id=<claim_id>...]
                          [--page=<page>] [--page_size=<page_size>] [--resolve]
 
         Options:
+            --name=<name>              : (str or list) channel name
+            --claim_id=<claim_id>      : (str or list) channel id
             --account_id=<account_id>  : (str) id of the account to use
             --wallet_id=<wallet_id>    : (str) restrict results to specific wallet
             --page=<page>              : (int) page to return during paginating
@@ -2716,15 +2715,9 @@ class Daemon(metaclass=JSONRPCServerType):
 
         Returns: {Paginated[Output]}
         """
-        wallet = self.wallet_manager.get_wallet_or_default(wallet_id)
-        if account_id:
-            account = wallet.get_account_or_error(account_id)
-            channels = account.get_channels
-            channel_count = account.get_channel_count
-        else:
-            channels = partial(self.ledger.get_channels, wallet=wallet, accounts=wallet.accounts)
-            channel_count = partial(self.ledger.get_channel_count, wallet=wallet, accounts=wallet.accounts)
-        return paginate_rows(channels, channel_count, page, page_size, resolve=resolve)
+        kwargs['type'] = 'channel'
+        kwargs['unspent'] = True
+        return self.jsonrpc_txo_list(*args, **kwargs)
 
     @requires(WALLET_COMPONENT)
     async def jsonrpc_channel_export(self, channel_id=None, channel_name=None, account_id=None, wallet_id=None):
@@ -3441,15 +3434,18 @@ class Daemon(metaclass=JSONRPCServerType):
         return tx
 
     @requires(WALLET_COMPONENT)
-    def jsonrpc_stream_list(self, account_id=None, wallet_id=None, page=None, page_size=None, resolve=False):
+    def jsonrpc_stream_list(self, *args, **kwargs):
         """
         List my stream claims.
 
         Usage:
             stream_list [<account_id> | --account_id=<account_id>] [--wallet_id=<wallet_id>]
-                       [--page=<page>] [--page_size=<page_size>] [--resolve]
+                        [--name=<name>...] [--claim_id=<claim_id>...]
+                        [--page=<page>] [--page_size=<page_size>] [--resolve]
 
         Options:
+            --name=<name>              : (str or list) stream name
+            --claim_id=<claim_id>      : (str or list) stream id
             --account_id=<account_id>  : (str) id of the account to query
             --wallet_id=<wallet_id>    : (str) restrict results to specific wallet
             --page=<page>              : (int) page to return during paginating
@@ -3458,15 +3454,9 @@ class Daemon(metaclass=JSONRPCServerType):
 
         Returns: {Paginated[Output]}
         """
-        wallet = self.wallet_manager.get_wallet_or_default(wallet_id)
-        if account_id:
-            account = wallet.get_account_or_error(account_id)
-            streams = account.get_streams
-            stream_count = account.get_stream_count
-        else:
-            streams = partial(self.ledger.get_streams, wallet=wallet, accounts=wallet.accounts)
-            stream_count = partial(self.ledger.get_stream_count, wallet=wallet, accounts=wallet.accounts)
-        return paginate_rows(streams, stream_count, page, page_size, resolve=resolve)
+        kwargs['type'] = 'stream'
+        kwargs['unspent'] = True
+        return self.jsonrpc_txo_list(*args, **kwargs)
 
     @requires(WALLET_COMPONENT, EXCHANGE_RATE_MANAGER_COMPONENT, BLOB_COMPONENT,
               DHT_COMPONENT, DATABASE_COMPONENT)
@@ -3912,15 +3902,18 @@ class Daemon(metaclass=JSONRPCServerType):
         return tx
 
     @requires(WALLET_COMPONENT)
-    def jsonrpc_support_list(self, account_id=None, wallet_id=None, page=None, page_size=None):
+    def jsonrpc_support_list(self, *args, **kwargs):
         """
         List supports and tips in my control.
 
         Usage:
             support_list [<account_id> | --account_id=<account_id>] [--wallet_id=<wallet_id>]
+                         [--name=<name>...] [--claim_id=<claim_id>...]
                          [--page=<page>] [--page_size=<page_size>]
 
         Options:
+            --name=<name>              : (str or list) claim name
+            --claim_id=<claim_id>      : (str or list) claim id
             --account_id=<account_id>  : (str) id of the account to query
             --wallet_id=<wallet_id>    : (str) restrict results to specific wallet
             --page=<page>              : (int) page to return during paginating
@@ -3928,15 +3921,9 @@ class Daemon(metaclass=JSONRPCServerType):
 
         Returns: {Paginated[Output]}
         """
-        wallet = self.wallet_manager.get_wallet_or_default(wallet_id)
-        if account_id:
-            account = wallet.get_account_or_error(account_id)
-            supports = account.get_supports
-            support_count = account.get_support_count
-        else:
-            supports = partial(self.ledger.get_supports, wallet=wallet, accounts=wallet.accounts)
-            support_count = partial(self.ledger.get_support_count, wallet=wallet, accounts=wallet.accounts)
-        return paginate_rows(supports, support_count, page, page_size)
+        kwargs['type'] = 'support'
+        kwargs['unspent'] = True
+        return self.jsonrpc_txo_list(*args, **kwargs)
 
     @requires(WALLET_COMPONENT)
     async def jsonrpc_support_abandon(
@@ -4103,12 +4090,60 @@ class Daemon(metaclass=JSONRPCServerType):
         """
         return self.wallet_manager.get_transaction(txid)
 
+    TXO_DOC = """
+    List transaction outputs.
+    """
+
+    @requires(WALLET_COMPONENT)
+    def jsonrpc_txo_list(
+            self, account_id=None, type=None, txid=None,  # pylint: disable=redefined-builtin
+            claim_id=None, name=None, unspent=False,
+            wallet_id=None, page=None, page_size=None, resolve=False):
+        """
+        List my transaction outputs.
+
+        Usage:
+            txo_list [--account_id=<account_id>] [--type=<type>...] [--txid=<txid>...]
+                     [--claim_id=<claim_id>...] [--name=<name>...] [--unspent]
+                     [--wallet_id=<wallet_id>]
+                     [--page=<page>] [--page_size=<page_size>]
+                     [--resolve]
+
+        Options:
+            --type=<type>              : (str or list) claim type: stream, channel, support,
+                                         purchase, collection, repost, other
+            --txid=<txid>              : (str or list) transaction id of outputs
+            --unspent                  : (bool) hide spent outputs, show only unspent ones
+            --claim_id=<claim_id>      : (str or list) claim id
+            --name=<name>              : (str or list) claim name
+            --account_id=<account_id>  : (str) id of the account to query
+            --wallet_id=<wallet_id>    : (str) restrict results to specific wallet
+            --page=<page>              : (int) page to return during paginating
+            --page_size=<page_size>    : (int) number of items on page during pagination
+            --resolve                  : (bool) resolves each claim to provide additional metadata
+
+        Returns: {Paginated[Output]}
+        """
+        wallet = self.wallet_manager.get_wallet_or_default(wallet_id)
+        if account_id:
+            account = wallet.get_account_or_error(account_id)
+            claims = account.get_txos
+            claim_count = account.get_txo_count
+        else:
+            claims = partial(self.ledger.get_txos, wallet=wallet, accounts=wallet.accounts)
+            claim_count = partial(self.ledger.get_txo_count, wallet=wallet, accounts=wallet.accounts)
+        constraints = {'resolve': resolve, 'unspent': unspent}
+        database.constrain_single_or_list(constraints, 'txo_type', type, lambda x: TXO_TYPES[x])
+        database.constrain_single_or_list(constraints, 'claim_id', claim_id)
+        database.constrain_single_or_list(constraints, 'claim_name', name)
+        return paginate_rows(claims, claim_count, page, page_size, **constraints)
+
     UTXO_DOC = """
     Unspent transaction management.
     """
 
     @requires(WALLET_COMPONENT)
-    def jsonrpc_utxo_list(self, account_id=None, wallet_id=None, page=None, page_size=None):
+    def jsonrpc_utxo_list(self, *args, **kwargs):
         """
         List unspent transaction outputs
 
@@ -4124,15 +4159,9 @@ class Daemon(metaclass=JSONRPCServerType):
 
         Returns: {Paginated[Output]}
         """
-        wallet = self.wallet_manager.get_wallet_or_default(wallet_id)
-        if account_id:
-            account = wallet.get_account_or_error(account_id)
-            utxos = account.get_utxos
-            utxo_count = account.get_utxo_count
-        else:
-            utxos = partial(self.ledger.get_utxos, wallet=wallet, accounts=wallet.accounts)
-            utxo_count = partial(self.ledger.get_utxo_count, wallet=wallet, accounts=wallet.accounts)
-        return paginate_rows(utxos, utxo_count, page, page_size)
+        kwargs['type'] = ['other', 'purchase']
+        kwargs['unspent'] = True
+        return self.jsonrpc_txo_list(*args, **kwargs)
 
     @requires(WALLET_COMPONENT)
     async def jsonrpc_utxo_release(self, account_id=None, wallet_id=None):

--- a/lbry/extras/daemon/json_response_encoder.py
+++ b/lbry/extras/daemon/json_response_encoder.py
@@ -25,7 +25,8 @@ def encode_txo_doc():
         'address': "address of who can spend the txo",
         'confirmations': "number of confirmed blocks",
         'is_change': "payment to change address, only available when it can be determined",
-        'is_spent': "true if txo is spent, false or None if it could not be determined",
+        'is_received': "true if txo was sent from external account to this account",
+        'is_spent': "true if txo is spent",
         'is_mine': "payment to one of your accounts, only available when it can be determined",
         'type': "one of 'claim', 'support' or 'purchase'",
         'name': "when type is 'claim' or 'support', this is the claim name",
@@ -169,6 +170,8 @@ class JSONResponseEncoder(JSONEncoder):
         }
         if txo.is_change is not None:
             output['is_change'] = txo.is_change
+        if txo.is_received is not None:
+            output['is_received'] = txo.is_received
         if txo.is_spent is not None:
             output['is_spent'] = txo.is_spent
         if txo.is_my_account is not None:

--- a/lbry/testcase.py
+++ b/lbry/testcase.py
@@ -564,6 +564,9 @@ class CommandTestCase(IntegrationTestCase):
     async def file_list(self, *args, **kwargs):
         return (await self.out(self.daemon.jsonrpc_file_list(*args, **kwargs)))['items']
 
+    async def txo_list(self, *args, **kwargs):
+        return (await self.out(self.daemon.jsonrpc_txo_list(*args, **kwargs)))['items']
+
     async def claim_list(self, *args, **kwargs):
         return (await self.out(self.daemon.jsonrpc_claim_list(*args, **kwargs)))['items']
 
@@ -572,6 +575,9 @@ class CommandTestCase(IntegrationTestCase):
 
     async def channel_list(self, *args, **kwargs):
         return (await self.out(self.daemon.jsonrpc_channel_list(*args, **kwargs)))['items']
+
+    async def transaction_list(self, *args, **kwargs):
+        return (await self.out(self.daemon.jsonrpc_transaction_list(*args, **kwargs)))['items']
 
     @staticmethod
     def get_claim_id(tx):

--- a/lbry/wallet/account.py
+++ b/lbry/wallet/account.py
@@ -467,6 +467,12 @@ class Account:
             'max_receiving_gap': receiving_gap,
         }
 
+    def get_txos(self, **constraints):
+        return self.ledger.get_txos(wallet=self.wallet, accounts=[self], **constraints)
+
+    def get_txo_count(self, **constraints):
+        return self.ledger.get_txo_count(wallet=self.wallet, accounts=[self], **constraints)
+
     def get_utxos(self, **constraints):
         return self.ledger.get_utxos(wallet=self.wallet, accounts=[self], **constraints)
 

--- a/lbry/wallet/constants.py
+++ b/lbry/wallet/constants.py
@@ -6,6 +6,7 @@ COIN = 100*CENT
 TIMEOUT = 30.0
 
 TXO_TYPES = {
+    "other": 0,
     "stream": 1,
     "channel": 2,
     "support": 3,
@@ -14,9 +15,13 @@ TXO_TYPES = {
     "repost": 6,
 }
 
+CLAIM_TYPE_NAMES = [
+    'stream',
+    'channel',
+    'collection',
+    'repost',
+]
+
 CLAIM_TYPES = [
-    TXO_TYPES['stream'],
-    TXO_TYPES['channel'],
-    TXO_TYPES['collection'],
-    TXO_TYPES['repost'],
+    TXO_TYPES[name] for name in CLAIM_TYPE_NAMES
 ]

--- a/lbry/wallet/transaction.py
+++ b/lbry/wallet/transaction.py
@@ -207,7 +207,7 @@ class OutputEffectiveAmountEstimator:
 class Output(InputOutput):
 
     __slots__ = (
-        'amount', 'script', 'is_change', 'is_spent', 'is_my_account',
+        'amount', 'script', 'is_change', 'is_spent', 'is_received', 'is_my_account',
         'channel', 'private_key', 'meta',
         'purchase', 'purchased_claim', 'purchase_receipt',
         'reposted_claim', 'claims',
@@ -216,7 +216,7 @@ class Output(InputOutput):
     def __init__(self, amount: int, script: OutputScript,
                  tx_ref: TXRef = None, position: int = None,
                  is_change: Optional[bool] = None, is_spent: Optional[bool] = None,
-                 is_my_account: Optional[bool] = None,
+                 is_received: Optional[bool] = None, is_my_account: Optional[bool] = None,
                  channel: Optional['Output'] = None, private_key: Optional[str] = None
                  ) -> None:
         super().__init__(tx_ref, position)
@@ -224,6 +224,7 @@ class Output(InputOutput):
         self.script = script
         self.is_change = is_change
         self.is_spent = is_spent
+        self.is_received = is_received
         self.is_my_account = is_my_account
         self.channel = channel
         self.private_key = private_key

--- a/tests/integration/blockchain/test_claim_commands.py
+++ b/tests/integration/blockchain/test_claim_commands.py
@@ -480,6 +480,26 @@ class TransactionOutputCommands(ClaimTestCase):
         self.assertTrue(r[0]['is_spent'])
         self.assertTrue(r[1]['is_spent'])
 
+    async def test_txo_list_received_filtering(self):
+        wallet2 = await self.daemon.jsonrpc_wallet_create('wallet2', create_account=True)
+        address2 = await self.daemon.jsonrpc_address_unused(wallet_id=wallet2.id)
+        await self.channel_create(claim_address=address2)
+
+        r = await self.txo_list(include_is_received=True)
+        self.assertEqual(2, len(r))
+        self.assertFalse(r[0]['is_received'])
+        self.assertTrue(r[1]['is_received'])
+        rt = await self.txo_list(is_not_received=True)
+        self.assertEqual(1, len(rt))
+        self.assertEqual(rt[0], r[0])
+        rf = await self.txo_list(is_received=True)
+        self.assertEqual(1, len(rf))
+        self.assertEqual(rf[0], r[1])
+
+        r = await self.txo_list(include_is_received=True, wallet_id=wallet2.id)
+        self.assertEqual(1, len(r))
+        self.assertTrue(r[0]['is_received'])
+
 
 class ClaimCommands(ClaimTestCase):
 


### PR DESCRIPTION
fixes #1853 the "Required" section