### PR TITLE
Handle MKV files

### DIFF
--- a/lbry/extras/daemon/daemon.py
+++ b/lbry/extras/daemon/daemon.py
@@ -3168,9 +3168,11 @@ class Daemon(metaclass=JSONRPCServerType):
                     f"Use --allow-duplicate-name flag to override."
                 )
 
-        file_path = await self._video_file_analyzer.verify_or_repair(
+        file_path, spec = await self._video_file_analyzer.verify_or_repair(
             validate_file, optimize_file, file_path, ignore_non_video=True
         )
+        kwargs.update(spec)
+
         claim = Claim()
         claim.stream.update(file_path=file_path, sd_hash='0' * 96, **kwargs)
         tx = await Transaction.claim_create(
@@ -3364,9 +3366,10 @@ class Daemon(metaclass=JSONRPCServerType):
         if fee_address:
             kwargs['fee_address'] = fee_address
 
-        file_path = await self._video_file_analyzer.verify_or_repair(
+        file_path, spec = await self._video_file_analyzer.verify_or_repair(
             validate_file, optimize_file, file_path, ignore_non_video=True
         )
+        kwargs.update(spec)
 
         if replace:
             claim = Claim()

--- a/lbry/schema/claim.py
+++ b/lbry/schema/claim.py
@@ -253,7 +253,7 @@ class Stream(BaseClaim):
         if stream_type in ('image', 'video', 'audio'):
             media = getattr(self, stream_type)
             media_args = {'file_metadata': None}
-            if file_path is not None:
+            if file_path is not None and not all((duration, width, height)):
                 try:
                     media_args['file_metadata'] = binary_file_metadata(binary_file_parser(file_path))
                 except:

--- a/scripts/check_video.py
+++ b/scripts/check_video.py
@@ -33,7 +33,7 @@ async def process_video(analyzer, video_file):
         transcode = input("Would you like to make a repaired clone now? [y/N] ")
         if transcode == "y":
             try:
-                new_video_file = await analyzer.verify_or_repair(True, True, video_file)
+                new_video_file, _ = await analyzer.verify_or_repair(True, True, video_file)
                 print("Successfully created ", new_video_file)
             except Exception as e:
                 print("Unable to complete the transcode. Message: ", str(e))

--- a/tests/integration/other/test_transcoding.py
+++ b/tests/integration/other/test_transcoding.py
@@ -52,12 +52,15 @@ class TranscodeValidation(ClaimTestCase):
                 self.assertEqual(code, 0, output)
 
     async def test_should_work(self):
-        new_file_name = await self.analyzer.verify_or_repair(True, False, self.video_file_name)
+        new_file_name, _ = await self.analyzer.verify_or_repair(True, False, self.video_file_name)
         self.assertEqual(self.video_file_name, new_file_name)
-        new_file_name = await self.analyzer.verify_or_repair(True, False, self.video_file_ogg)
+        new_file_name, _ = await self.analyzer.verify_or_repair(True, False, self.video_file_ogg)
         self.assertEqual(self.video_file_ogg, new_file_name)
-        new_file_name = await self.analyzer.verify_or_repair(True, False, self.video_file_webm)
+        new_file_name, spec = await self.analyzer.verify_or_repair(True, False, self.video_file_webm)
         self.assertEqual(self.video_file_webm, new_file_name)
+        self.assertEqual(spec["width"], 1280)
+        self.assertEqual(spec["height"], 720)
+        self.assertEqual(spec["duration"], 15.054)
 
     async def test_volume(self):
         self.conf.volume_analysis_time = 200
@@ -75,7 +78,7 @@ class TranscodeValidation(ClaimTestCase):
         with self.assertRaisesRegex(Exception, "Container format is not in the approved list"):
             await self.analyzer.verify_or_repair(True, False, file_name)
 
-        fixed_file = await self.analyzer.verify_or_repair(True, True, file_name)
+        fixed_file, _ = await self.analyzer.verify_or_repair(True, True, file_name)
         pathlib.Path(fixed_file).unlink()
 
     async def test_video_codec(self):
@@ -91,7 +94,7 @@ class TranscodeValidation(ClaimTestCase):
         with self.assertRaisesRegex(Exception, "faststart flag was not used"):
             await self.analyzer.verify_or_repair(True, False, file_name)
 
-        fixed_file = await self.analyzer.verify_or_repair(True, True, file_name)
+        fixed_file, _ = await self.analyzer.verify_or_repair(True, True, file_name)
         pathlib.Path(fixed_file).unlink()
 
     async def test_max_bit_rate(self):
@@ -111,7 +114,7 @@ class TranscodeValidation(ClaimTestCase):
         with self.assertRaisesRegex(Exception, "pixel format does not match the approved"):
             await self.analyzer.verify_or_repair(True, False, file_name)
 
-        fixed_file = await self.analyzer.verify_or_repair(True, True, file_name)
+        fixed_file, _ = await self.analyzer.verify_or_repair(True, True, file_name)
         pathlib.Path(fixed_file).unlink()
 
     async def test_audio_codec(self):
@@ -125,7 +128,7 @@ class TranscodeValidation(ClaimTestCase):
         with self.assertRaisesRegex(Exception, "Audio codec is not in the approved list"):
             await self.analyzer.verify_or_repair(True, False, file_name)
 
-        fixed_file = await self.analyzer.verify_or_repair(True, True, file_name)
+        fixed_file, _ = await self.analyzer.verify_or_repair(True, True, file_name)
         pathlib.Path(fixed_file).unlink()
 
     async def test_extension_choice(self):


### PR DESCRIPTION
Fixes #2868

1. Verifies that MKV files are WebM compatible
2. Reuses the height/width/duration data from ffmpeg if possible.