### PR TITLE
added `txo_spend` command to support liquidating large number of txos (eg. tips) by batching them across several transactions

### DIFF
--- a/lbry/extras/daemon/daemon.py
+++ b/lbry/extras/daemon/daemon.py
@@ -4260,7 +4260,7 @@ class Daemon(metaclass=JSONRPCServerType):
                       [--claim_id=<claim_id>...] [--channel_id=<channel_id>...] [--name=<name>...]
                       [--is_my_input | --is_not_my_input]
                       [--exclude_internal_transfers] [--wallet_id=<wallet_id>]
-                      [--batch_size=<batch_size>]
+                      [--preview] [--blocking] [--batch_size=<batch_size>]
 
         Options:
             --type=<type>              : (str or list) claim type: stream, channel, support,
@@ -4277,6 +4277,8 @@ class Daemon(metaclass=JSONRPCServerType):
                                                 flag can be used in combination with any of the other flags
             --account_id=<account_id>  : (str) id of the account to query
             --wallet_id=<wallet_id>    : (str) restrict results to specific wallet
+            --preview                  : (bool) do not broadcast the transaction
+            --blocking                 : (bool) wait until abandon is in mempool
             --batch_size=<batch_size>  : (int) number of txos to spend per transactions
 
         Returns: {List[Transaction]}

--- a/lbry/extras/daemon/daemon.py
+++ b/lbry/extras/daemon/daemon.py
@@ -4251,7 +4251,7 @@ class Daemon(metaclass=JSONRPCServerType):
     @requires(WALLET_COMPONENT)
     async def jsonrpc_txo_spend(
             self, account_id=None, wallet_id=None, batch_size=1000,
-            preview=False, blocking=False, **kwargs):
+            include_full_tx=False, preview=False, blocking=False, **kwargs):
         """
         Spend transaction outputs, batching into multiple transactions as necessary.
 
@@ -4280,6 +4280,7 @@ class Daemon(metaclass=JSONRPCServerType):
             --preview                  : (bool) do not broadcast the transaction
             --blocking                 : (bool) wait until abandon is in mempool
             --batch_size=<batch_size>  : (int) number of txos to spend per transactions
+            --include_full_tx          : (bool) include entire tx in output and not just the txid
 
         Returns: {List[Transaction]}
         """
@@ -4300,7 +4301,9 @@ class Daemon(metaclass=JSONRPCServerType):
         if not preview:
             for tx in txs:
                 await self.broadcast_or_release(tx, blocking)
-        return txs
+        if include_full_tx:
+            return txs
+        return [{'txid': tx.id} for tx in txs]
 
     @requires(WALLET_COMPONENT)
     def jsonrpc_txo_sum(self, account_id=None, wallet_id=None, **kwargs):

--- a/lbry/testcase.py
+++ b/lbry/testcase.py
@@ -565,6 +565,14 @@ class CommandTestCase(IntegrationTestCase):
             self.daemon.jsonrpc_wallet_send(*args, **kwargs), confirm
         )
 
+    async def txo_spend(self, *args, confirm=True, **kwargs):
+        txs = await self.daemon.jsonrpc_txo_spend(*args, **kwargs)
+        if confirm:
+            await asyncio.wait([self.ledger.wait(tx) for tx in txs])
+            await self.generate(1)
+            await asyncio.wait([self.ledger.wait(tx, self.blockchain.block_expected) for tx in txs])
+        return self.sout(txs)
+
     async def resolve(self, uri, **kwargs):
         return (await self.out(self.daemon.jsonrpc_resolve(uri, **kwargs)))[uri]
 

--- a/lbry/wallet/ledger.py
+++ b/lbry/wallet/ledger.py
@@ -266,7 +266,7 @@ class Ledger(metaclass=LedgerRegistry):
         self.constraint_spending_utxos(constraints)
         return self.db.get_utxo_count(**constraints)
 
-    async def get_txos(self, resolve=False, **constraints):
+    async def get_txos(self, resolve=False, **constraints) -> List[Output]:
         txos = await self.db.get_txos(**constraints)
         if resolve:
             return await self._resolve_for_local_results(constraints.get('accounts', []), txos)

--- a/tests/integration/blockchain/test_claim_commands.py
+++ b/tests/integration/blockchain/test_claim_commands.py
@@ -610,6 +610,21 @@ class TransactionOutputCommands(ClaimTestCase):
             {'day': '2016-06-25', 'total': '0.6'},
         ], plot)
 
+    async def test_txo_spend(self):
+        stream_id = self.get_claim_id(await self.stream_create())
+        for _ in range(10):
+            await self.support_create(stream_id, '0.1')
+        await self.assertBalance(self.account, '7.978478')
+        self.assertEqual('1.0', lbc(await self.txo_sum(type='support', unspent=True)))
+        txs = await self.txo_spend(type='support', batch_size=3)
+        self.assertEqual(4, len(txs))
+        self.assertEqual(3, len(txs[0]['inputs']))
+        self.assertEqual(3, len(txs[1]['inputs']))
+        self.assertEqual(3, len(txs[2]['inputs']))
+        self.assertEqual(1, len(txs[3]['inputs']))
+        self.assertEqual('0.0', lbc(await self.txo_sum(type='support', unspent=True)))
+        await self.assertBalance(self.account, '8.977606')
+
 
 class ClaimCommands(ClaimTestCase):
 

--- a/tests/integration/blockchain/test_claim_commands.py
+++ b/tests/integration/blockchain/test_claim_commands.py
@@ -616,7 +616,7 @@ class TransactionOutputCommands(ClaimTestCase):
             await self.support_create(stream_id, '0.1')
         await self.assertBalance(self.account, '7.978478')
         self.assertEqual('1.0', lbc(await self.txo_sum(type='support', unspent=True)))
-        txs = await self.txo_spend(type='support', batch_size=3)
+        txs = await self.txo_spend(type='support', batch_size=3, include_full_tx=True)
         self.assertEqual(4, len(txs))
         self.assertEqual(3, len(txs[0]['inputs']))
         self.assertEqual(3, len(txs[1]['inputs']))
@@ -624,6 +624,11 @@ class TransactionOutputCommands(ClaimTestCase):
         self.assertEqual(1, len(txs[3]['inputs']))
         self.assertEqual('0.0', lbc(await self.txo_sum(type='support', unspent=True)))
         await self.assertBalance(self.account, '8.977606')
+
+        await self.support_create(stream_id, '0.1')
+        txs = await self.daemon.jsonrpc_txo_spend(type='support', batch_size=3)
+        self.assertEqual(1, len(txs))
+        self.assertEqual({'txid'}, set(txs[0]))
 
 
 class ClaimCommands(ClaimTestCase):


### PR DESCRIPTION
fixes #2847
fixes #2528
fixes #941