### PR TITLE
improve speed of `status`

### DIFF
--- a/lbry/extras/daemon/daemon.py
+++ b/lbry/extras/daemon/daemon.py
@@ -785,7 +785,7 @@ class Daemon(metaclass=JSONRPCServerType):
                 'analyze_audio_volume': (bool) should ffmpeg analyze audio
             }
         """
-        return await self._video_file_analyzer.status(reset=True)
+        return await self._video_file_analyzer.status(reset=True, recheck=True)
 
     async def jsonrpc_status(self):
         """

--- a/lbry/file_analysis.py
+++ b/lbry/file_analysis.py
@@ -30,6 +30,7 @@ class VideoFileAnalyzer:
         self._which_ffmpeg = None
         self._which_ffprobe = None
         self._env_copy = dict(os.environ)
+        self._checked_ffmpeg = False
         if lbry.utils.is_running_from_bundle():
             # handle the situation where PyInstaller overrides our runtime environment:
             self._replace_or_pop_env('LD_LIBRARY_PATH')
@@ -94,15 +95,18 @@ class VideoFileAnalyzer:
         await self._verify_executables()
         self._ffmpeg_installed = True
 
-    async def status(self, reset=False):
+    async def status(self, reset=False, recheck=False):
         if reset:
             self._available_encoders = ""
             self._ffmpeg_installed = None
-        if self._ffmpeg_installed is None:
+        if self._checked_ffmpeg and not recheck:
+            pass
+        elif self._ffmpeg_installed is None:
             try:
                 await self._verify_ffmpeg_installed()
             except FileNotFoundError:
                 pass
+            self._checked_ffmpeg = True
         return {
             "available": self._ffmpeg_installed,
             "which": self._which_ffmpeg,

--- a/tests/integration/other/test_transcoding.py
+++ b/tests/integration/other/test_transcoding.py
@@ -160,3 +160,26 @@ class TranscodeValidation(ClaimTestCase):
         await self.analyzer.status(reset=True)
         with self.assertRaisesRegex(Exception, "Unable to locate"):
             await self.analyzer.verify_or_repair(True, False, self.video_file_name)
+
+    async def test_dont_recheck_ffmpeg_installation(self):
+
+        call_count = 0
+
+        original = self.daemon._video_file_analyzer._verify_ffmpeg_installed
+
+        def _verify_ffmpeg_installed():
+            nonlocal call_count
+            call_count += 1
+            return original()
+
+        self.daemon._video_file_analyzer._verify_ffmpeg_installed = _verify_ffmpeg_installed
+        self.assertEqual(0, call_count)
+        await self.daemon.jsonrpc_status()
+        self.assertEqual(1, call_count)
+        # counter should not go up again
+        await self.daemon.jsonrpc_status()
+        self.assertEqual(1, call_count)
+
+        # this should force rechecking the installation
+        await self.daemon.jsonrpc_ffmpeg_find()
+        self.assertEqual(2, call_count)


### PR DESCRIPTION
-fixes ffmpeg installation being rechecked (reintroduced in https://github.com/lbryio/lbry-sdk/pull/2861)
-don't block `status` on the internet connection check if it was needed