### PR TITLE
use home directory if xdg directory not found (Linux)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ install:
 	pip install -e .
 
 tools:
-	pip install mypy==0.701
+	pip install mypy==0.701 pylint==2.4.4
 	pip install coverage astroid pylint
 
 lint:

--- a/lbry/conf.py
+++ b/lbry/conf.py
@@ -691,9 +691,10 @@ def get_darwin_directories() -> typing.Tuple[str, str, str]:
 def get_linux_directories() -> typing.Tuple[str, str, str]:
     try:
         with open(os.path.join(user_config_dir(), 'user-dirs.dirs'), 'r') as xdg:
-            down_dir = re.search(r'XDG_DOWNLOAD_DIR=(.+)', xdg.read()).group(1)
-        down_dir = re.sub(r'\$HOME', os.getenv('HOME') or os.path.expanduser("~/"), down_dir)
-        download_dir = re.sub('\"', '', down_dir)
+            down_dir = re.search(r'XDG_DOWNLOAD_DIR=(.+)', xdg.read())
+        if down_dir:
+            down_dir = re.sub(r'\$HOME', os.getenv('HOME') or os.path.expanduser("~/"), down_dir.group(1))
+            download_dir = re.sub('\"', '', down_dir)
     except OSError:
         download_dir = os.getenv('XDG_DOWNLOAD_DIR')
     if not download_dir:


### PR DESCRIPTION
Fixes  an error in detecting xdg config locations when XDG_DOWNLOAD_DIR is not present in `user-dirs.dirs`
Lemme know if I've done anything stupid, it seems to work but you never know.
Fixes #2913