### PR TITLE
properly handle integer environment values, fixes issue with specifying ports via environment vars

### DIFF
--- a/lbry/conf.py
+++ b/lbry/conf.py
@@ -279,7 +279,7 @@ class EnvironmentAccess:
 
     def __init__(self, config: 'BaseConfig', environ: dict):
         self.configuration = config
-        self.environ = {}
+        self.data = {}
         if environ:
             self.load(environ)
 
@@ -287,13 +287,13 @@ class EnvironmentAccess:
         for setting in self.configuration.get_settings():
             value = environ.get(f'{self.PREFIX}{setting.name.upper()}', NOT_SET)
             if value != NOT_SET and not (isinstance(setting, ListSetting) and value is None):
-                self.environ[f'{self.PREFIX}{setting.name.upper()}'] = setting.deserialize(value)
+                self.data[setting.name] = setting.deserialize(value)
 
     def __contains__(self, item: str):
-        return f'{self.PREFIX}{item.upper()}' in self.environ
+        return item in self.data
 
     def __getitem__(self, item: str):
-        return self.environ[f'{self.PREFIX}{item.upper()}']
+        return self.data[item]
 
 
 class ArgumentAccess:
@@ -452,7 +452,7 @@ class BaseConfig:
         self.arguments = ArgumentAccess(self, args)
 
     def set_environment(self, environ=None):
-        self.environment = EnvironmentAccess(self, dict(environ or os.environ))
+        self.environment = EnvironmentAccess(self, environ or os.environ)
 
     def set_persisted(self, config_file_path=None):
         if config_file_path is None:

--- a/tests/unit/test_conf.py
+++ b/tests/unit/test_conf.py
@@ -93,6 +93,11 @@ class ConfigurationTests(unittest.TestCase):
         self.assertEqual(c.test_str, 'the default')
         c.set_environment({'LBRY_TEST_STR': 'from environ'})
         self.assertEqual(c.test_str, 'from environ')
+        
+        c = TestConfig()
+        self.assertEqual(c.test_int, 9)
+        c.set_environment({'LBRY_TEST_INT': '1'})
+        self.assertEqual(c.test_int, 1)
 
     def test_persisted(self):
         with tempfile.TemporaryDirectory() as temp_dir:

--- a/tests/unit/test_conf.py
+++ b/tests/unit/test_conf.py
@@ -90,11 +90,11 @@ class ConfigurationTests(unittest.TestCase):
 
     def test_environment(self):
         c = TestConfig()
+
         self.assertEqual(c.test_str, 'the default')
         c.set_environment({'LBRY_TEST_STR': 'from environ'})
         self.assertEqual(c.test_str, 'from environ')
-        
-        c = TestConfig()
+
         self.assertEqual(c.test_int, 9)
         c.set_environment({'LBRY_TEST_INT': '1'})
         self.assertEqual(c.test_int, 1)


### PR DESCRIPTION
make sure tcp and udp port for dht are int type

Reason for fix (Ubuntu 20.04 and desktop app):
1. Without fix users specify env vars, LBRY_TCP_PORT=34562 and LBRY_UDP_PORT=34562, but then when you run the daemon it complains about string comparisons.
2. With this fix people can download the desktop application, set the above environment variables and have their seeding working with VPN! PIA VPN gives you a randomly assigned port forward port, with this fix a user can now use a VPN (with ENV vars).