### PR TITLE
fix duplicate line on api doc

### DIFF
--- a/lbry/extras/daemon/daemon.py
+++ b/lbry/extras/daemon/daemon.py
@@ -3613,7 +3613,6 @@ class Daemon(metaclass=JSONRPCServerType):
                                                     given name. default: false.
             --title=<title>                : (str) title of the collection
             --description=<description>    : (str) description of the collection
-            --clear_languages              : (bool) clear existing languages (prior to adding new ones)
             --tags=<tags>                  : (list) content tags
             --clear_languages              : (bool) clear existing languages (prior to adding new ones)
             --languages=<languages>        : (list) languages used by the collection,


### PR DESCRIPTION
delete line 3616 (duplicate line 3618)

tested on Linux with pycharm venv 

- api.json  with duplicate line:
![image](https://user-images.githubusercontent.com/34900176/81321982-a99fa800-9069-11ea-941a-91df070e1035.png)

- fixed api.json doc test result:
![image](https://user-images.githubusercontent.com/34900176/81322172-f3888e00-9069-11ea-8074-096e98c6422f.png)
