### PR TITLE
more aggressive video transcoding to reduce file sizes

### DIFF
--- a/lbry/conf.py
+++ b/lbry/conf.py
@@ -478,12 +478,12 @@ class TranscodeConfig(BaseConfig):
                          '', previous_names=['ffmpeg_folder'])
     video_encoder = String('FFmpeg codec and parameters for the video encoding. '
                            'Example: libaom-av1 -crf 25 -b:v 0 -strict experimental',
-                           'libx264 -crf 21 -preset faster -pix_fmt yuv420p')
+                           'libx264 -crf 24 -preset faster -pix_fmt yuv420p')
     video_bitrate_maximum = Integer('Maximum bits per second allowed for video streams (0 to disable).', 8400000)
     video_scaler = String('FFmpeg scaling parameters for reducing bitrate. '
                           'Example: -vf "scale=-2:720,fps=24" -maxrate 5M -bufsize 3M',
                           r'-vf "scale=if(gte(iw\,ih)\,min(1920\,iw)\,-2):if(lt(iw\,ih)\,min(1920\,ih)\,-2)" '
-                          r'-maxrate 8400K -bufsize 5000K')
+                          r'-maxrate 5500K -bufsize 5000K')
     audio_encoder = String('FFmpeg codec and parameters for the audio encoding. '
                            'Example: libopus -b:a 128k',
                            'aac -b:a 160k')


### PR DESCRIPTION
Have noticed the defaults aren't aggressive enough to stream smoothly (yet). Downgrade max rate to 5500K, higher crf = smaller file size for now.