### PR TITLE
Improve wallet server address history cache and the rate of sent notifications

### DIFF
--- a/lbry/wallet/server/block_processor.py
+++ b/lbry/wallet/server/block_processor.py
@@ -183,6 +183,7 @@ class BlockProcessor:
         self.state_lock = asyncio.Lock()
 
         self.search_cache = {}
+        self.history_cache = {}
 
     async def run_in_thread_with_lock(self, func, *args):
         # Run in a thread to prevent blocking.  Shielded so that
@@ -213,6 +214,7 @@ class BlockProcessor:
             await self.run_in_thread_with_lock(self.advance_blocks, blocks)
             for cache in self.search_cache.values():
                 cache.clear()
+            self.history_cache.clear()
             await self._maybe_flush()
             processed_time = time.perf_counter() - start
             self.block_count_metric.set(self.height)


### PR DESCRIPTION
Minimizes but does not entirely solve https://github.com/lbryio/lbry-sdk/issues/2945 as the cache is invalidated each block and the first slow request can back up further notifications during the same block.