### PR TITLE
Added Better Permission Checks for Configuration Directories

### DIFF
--- a/lbry/extras/cli.py
+++ b/lbry/extras/cli.py
@@ -224,8 +224,15 @@ def get_argument_parser():
 
 
 def ensure_directory_exists(path: str):
-    if not os.path.isdir(path):
-        pathlib.Path(path).mkdir(parents=True, exist_ok=True)
+    pathObj = pathlib.Path(path)
+    try:
+        if pathObj.is_dir():
+            pathObj.chmod(0o777)
+        else:
+            pathObj.mkdir(parents=True, exist_ok=True)
+    except:
+        print("Could not access", path)
+        sys.exit(1)
 
 
 LOG_MODULES = 'lbry', 'aioupnp'

--- a/lbry/extras/cli.py
+++ b/lbry/extras/cli.py
@@ -224,13 +224,13 @@ def get_argument_parser():
 
 
 def ensure_directory_exists(path: str):
-    pathObj = pathlib.Path(path)
+    path_obj = pathlib.Path(path)
     try:
-        if pathObj.is_dir():
-            pathObj.chmod(0o777)
+        if path_obj.is_dir():
+            path_obj.chmod(0o777)
         else:
-            pathObj.mkdir(parents=True, exist_ok=True)
-    except:
+            path_obj.mkdir(parents=True, exist_ok=True)
+    except PermissionError:
         print("Could not access", path)
         sys.exit(1)
 

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ with open(os.path.join(BASE, 'README.md'), encoding='utf-8') as fh:
 
 PLYVEL = []
 if sys.platform.startswith('linux'):
-    PLYVEL.append('plyvel==1.0.5')
+    PLYVEL.append('plyvel==1.2.0')
 
 setup(
     name=__name__,


### PR DESCRIPTION
Inspired by Bug #877, this amends the initial checks for directories required by the daemon. Additionally, this self fixes permissions for the directories. 

I'd like to add the option to not exit the daemon when optional directories are inaccessible, but I'm not sure which are important. In my testing, "~/Downloads" seems to be 1 of those optional directories.

Also, it maybe be useful to set the directory permissions to 755 instead of 777. Your thoughts?

P. S. I can't replicate the issue described in #877. I think PR #2454 fixed the issue, but the changes may have gotten lost in a merge (I can't find them in a current version). 