### PR TITLE
Add webvtt mime type ( subtitles, captions )

### DIFF
--- a/lbry/schema/mime_types.py
+++ b/lbry/schema/mime_types.py
@@ -123,6 +123,7 @@ types_map = {
     '.txt': ('text/plain', 'document'),
     '.ustar': ('application/x-ustar', 'binary'),
     '.vcf': ('text/x-vcard', 'document'),
+    '.vtt': ('text/vtt', 'document'),
     '.wav': ('audio/x-wav', 'audio'),
     '.webm': ('video/webm', 'video'),
     '.wiz': ('application/msword', 'document'),


### PR DESCRIPTION
> Web Video Text Tracks Format (WebVTT) is a format for displaying timed text tracks (such as subtitles or captions) using the <track> element.

> The MIME type of WebVTT is text/vtt.

https://developer.mozilla.org/en-US/docs/Web/API/WebVTT_API