### PR TITLE
Fixed docker-compose - no snapshot error

### DIFF
--- a/docker/docker-compose-wallet-server.yml
+++ b/docker/docker-compose-wallet-server.yml
@@ -16,7 +16,8 @@ services:
       - "lbrycrd:/data/.lbrycrd"
     environment:
       - RUN_MODE=default
-      - SNAPSHOT_URL=${LBRYCRD_SNAPSHOT_URL-https://lbry.com/snapshot/blockchain}
+      # Curently not snapshot provided
+      #- SNAPSHOT_URL=${LBRYCRD_SNAPSHOT_URL-https://lbry.com/snapshot/blockchain}
       - RPC_ALLOW_IP=0.0.0.0/0
   wallet_server:
     image: lbry/wallet-server:${WALLET_SERVER_TAG:-latest-release}
@@ -30,5 +31,6 @@ services:
     volumes:
       - "wallet_server:/database"
     environment:
-      - SNAPSHOT_URL=${WALLET_SERVER_SNAPSHOT_URL-https://lbry.com/snapshot/wallet}
+      # Curently not snapshot provided
+      # - SNAPSHOT_URL=${WALLET_SERVER_SNAPSHOT_URL-https://lbry.com/snapshot/wallet}
       - DAEMON_URL=http://lbry:lbry@lbrycrd:9245


### PR DESCRIPTION
Curently new containers do not get provide snapshots from LBRYinc (Wallet and CRD) that causes containers to get into restart loop.