### PR TITLE
store transactions for wallet server in leveldb instead of requesting from lbrycrd

### DIFF
--- a/lbry/wallet/ledger.py
+++ b/lbry/wallet/ledger.py
@@ -722,7 +722,7 @@ class Ledger(metaclass=LedgerRegistry):
                 if cache_item is None:
                     cache_item = TransactionCacheItem()
                     self._tx_cache[txid] = cache_item
-                tx = cache_item.tx or Transaction(unhexlify(raw), height=remote_height)
+                tx = cache_item.tx or Transaction(bytes.fromhex(raw), height=remote_height)
                 tx.height = remote_height
                 cache_item.tx = tx
                 if 'merkle' in merkle and remote_heights[txid] > 0:

--- a/lbry/wallet/server/block_processor.py
+++ b/lbry/wallet/server/block_processor.py
@@ -171,7 +171,7 @@ class BlockProcessor:
 
         # Caches of unflushed items.
         self.headers = []
-        self.tx_hashes = []
+        self.block_txs = []
         self.undo_infos = []
 
         # UTXO cache
@@ -337,7 +337,7 @@ class BlockProcessor:
         """The data for a flush.  The lock must be taken."""
         assert self.state_lock.locked()
         return FlushData(self.height, self.tx_count, self.headers,
-                         self.tx_hashes, self.undo_infos, self.utxo_cache,
+                         self.block_txs, self.undo_infos, self.utxo_cache,
                          self.db_deletes, self.tip)
 
     async def flush(self, flush_utxos):
@@ -404,7 +404,7 @@ class BlockProcessor:
         self.tip = self.coin.header_hash(headers[-1])
 
     def advance_txs(self, height, txs, header):
-        self.tx_hashes.append(b''.join(tx_hash for tx, tx_hash in txs))
+        self.block_txs.append((b''.join(tx_hash for tx, tx_hash in txs), [tx for tx, _ in txs]))
 
         # Use local vars for speed in the loops
         undo_info = []

--- a/lbry/wallet/server/leveldb.py
+++ b/lbry/wallet/server/leveldb.py
@@ -426,19 +426,6 @@ class LevelDB:
 
         return await asyncio.get_event_loop().run_in_executor(self.executor, read_headers)
 
-    async def fs_block_tx_hashes(self, height):
-        def _get_tx_hashes():
-            return self.tx_db.get(BLOCK_HASH_PREFIX + util.pack_be_uint64(height)).hex().decode(), list(map(
-                    lambda tx_hash: hash_to_hex_str(tx_hash).decode(),
-                    self.tx_db.iterator(
-                        start=TX_HASH_PREFIX + util.pack_be_uint64(self.tx_counts[height - 1]),
-                        stop=None if height + 1 == len(self.tx_counts) else TX_HASH_PREFIX + util.pack_be_uint64(self.tx_counts[height]),
-                        include_key=False
-                    )
-                ))
-
-        return await asyncio.get_event_loop().run_in_executor(self.executor, _get_tx_hashes)
-
     def fs_tx_hash(self, tx_num):
         """Return a par (tx_hash, tx_height) for the given tx number.
 

--- a/lbry/wallet/server/merkle.py
+++ b/lbry/wallet/server/merkle.py
@@ -63,7 +63,7 @@ class Merkle:
             raise TypeError('index must be an integer')
         # This also asserts hashes is not empty
         if not 0 <= index < len(hashes):
-            raise ValueError('index out of range')
+            raise ValueError(f"index '{index}/{len(hashes)}' out of range")
         natural_length = self.branch_length(len(hashes))
         if length is None:
             length = natural_length

--- a/lbry/wallet/server/session.py
+++ b/lbry/wallet/server/session.py
@@ -1585,15 +1585,6 @@ class LBRYElectrumX(SessionBase):
 
         return await self.daemon_request('getrawtransaction', tx_hash, verbose)
 
-    async def _block_hash_and_tx_hashes(self, height):
-        """Returns a pair (block_hash, tx_hashes) for the main chain block at
-        the given height.
-
-        block_hash is a hexadecimal string, and tx_hashes is an
-        ordered list of hexadecimal strings.
-        """
-        return await self.db.fs_block_tx_hashes(height)
-
     def _get_merkle_branch(self, tx_hashes, tx_pos):
         """Return a merkle branch to a transaction.
 

--- a/lbry/wallet/server/storage.py
+++ b/lbry/wallet/server/storage.py
@@ -77,18 +77,16 @@ class LevelDB(Storage):
         import plyvel
         cls.module = plyvel
 
-    def open(self, name, create):
-        mof = 512 if self.for_sync else 128
+    def open(self, name, create, lru_cache_size=None):
+        mof = 10000
         path = os.path.join(self.db_dir, name)
         # Use snappy compression (the default)
-        self.db = self.module.DB(path, create_if_missing=create,
-                                 max_open_files=mof)
+        self.db = self.module.DB(path, create_if_missing=create, max_open_files=mof)
         self.close = self.db.close
         self.get = self.db.get
         self.put = self.db.put
         self.iterator = self.db.iterator
-        self.write_batch = partial(self.db.write_batch, transaction=True,
-                                   sync=True)
+        self.write_batch = partial(self.db.write_batch, transaction=True, sync=True)
 
 
 class RocksDB(Storage):


### PR DESCRIPTION
improves performance of `blockchain.transaction.get_batch` and `blockchain.transaction.get_info`