### PR TITLE
drop the ability to refer to claims by number from the LBRY URL scheme

### DIFF
--- a/lbry/schema/url.py
+++ b/lbry/schema/url.py
@@ -23,7 +23,6 @@ def _create_url_regex():
             _named(name+"_name", prefix + invalid_names_regex) +
             _oneof(
                 _group('[:#]' + _named(name+"_claim_id", "[0-9a-f]{1,40}")),
-                _group(r'\*' + _named(name+"_sequence", '[1-9][0-9]*')),
                 _group(r'\$' + _named(name+"_amount_order", '[1-9][0-9]*'))
             ) + '?'
         )
@@ -50,7 +49,6 @@ def normalize_name(name):
 class PathSegment(NamedTuple):
     name: str
     claim_id: str = None
-    sequence: int = None
     amount_order: int = None
 
     @property
@@ -61,8 +59,6 @@ class PathSegment(NamedTuple):
         q = {'name': self.name}
         if self.claim_id is not None:
             q['claim_id'] = self.claim_id
-        if self.sequence is not None:
-            q['sequence'] = self.sequence
         if self.amount_order is not None:
             q['amount_order'] = self.amount_order
         return q
@@ -70,8 +66,6 @@ class PathSegment(NamedTuple):
     def __str__(self):
         if self.claim_id is not None:
             return f"{self.name}:{self.claim_id}"
-        elif self.sequence is not None:
-            return f"{self.name}*{self.sequence}"
         elif self.amount_order is not None:
             return f"{self.name}${self.amount_order}"
         return self.name
@@ -118,7 +112,6 @@ class URL(NamedTuple):
                 segments[segment] = PathSegment(
                     parts[f'{segment}_name'],
                     parts[f'{segment}_claim_id'],
-                    parts[f'{segment}_sequence'],
                     parts[f'{segment}_amount_order']
                 )
 

--- a/tests/integration/blockchain/test_resolve_command.py
+++ b/tests/integration/blockchain/test_resolve_command.py
@@ -117,11 +117,6 @@ class ResolveCommand(BaseResolveTestCase):
             await self.stream_create('foo', '0.9', allow_duplicate_name=True))
         # plain winning claim
         await self.assertResolvesToClaimId('foo', claim_id3)
-        # sequence resolution
-        await self.assertResolvesToClaimId('foo*1', claim_id1)
-        await self.assertResolvesToClaimId('foo*2', claim_id2)
-        await self.assertResolvesToClaimId('foo*3', claim_id3)
-        await self.assertResolvesToClaimId('foo*4', None)
         # amount order resolution
         await self.assertResolvesToClaimId('foo$1', claim_id3)
         await self.assertResolvesToClaimId('foo$2', claim_id2)

--- a/tests/unit/schema/test_url.py
+++ b/tests/unit/schema/test_url.py
@@ -9,7 +9,7 @@ claim_id = "63f2da17b0d90042c559cc73b6b17f853945c43e"
 class TestURLParsing(unittest.TestCase):
 
     segments = 'stream', 'channel'
-    fields = 'name', 'claim_id', 'sequence', 'amount_order'
+    fields = 'name', 'claim_id', 'amount_order'
 
     def _assert_url(self, url_string, strictly=True, **kwargs):
         url = URL.parse(url_string)
@@ -43,25 +43,22 @@ class TestURLParsing(unittest.TestCase):
         url = self._assert_url
         # stream
         url('test', stream_name='test')
-        url('test*1', stream_name='test', stream_sequence='1')
+        url('test*1', stream_name='test*1')
         url('test$1', stream_name='test', stream_amount_order='1')
         url(f'test#{claim_id}', stream_name='test', stream_claim_id=claim_id, strictly=False)
         url(f'test:{claim_id}', stream_name='test', stream_claim_id=claim_id)
         # channel
         url('@test', channel_name='@test')
-        url('@test*1', channel_name='@test', channel_sequence='1')
         url('@test$1', channel_name='@test', channel_amount_order='1')
         url(f'@test#{claim_id}', channel_name='@test', channel_claim_id=claim_id, strictly=False)
         url(f'@test:{claim_id}', channel_name='@test', channel_claim_id=claim_id)
         # channel/stream
         url('lbry://@test/stuff', channel_name='@test', stream_name='stuff')
-        url('lbry://@test*1/stuff', channel_name='@test', channel_sequence='1', stream_name='stuff')
         url('lbry://@test$1/stuff', channel_name='@test', channel_amount_order='1', stream_name='stuff')
         url(f'lbry://@test#{claim_id}/stuff', channel_name='@test', channel_claim_id=claim_id, stream_name='stuff', strictly=False)
         url(f'lbry://@test:{claim_id}/stuff', channel_name='@test', channel_claim_id=claim_id, stream_name='stuff')
         # combined legacy and new
         url('@test:1/stuff#2', channel_claim_id='1', stream_claim_id='2', channel_name='@test', stream_name='stuff', strictly=False)
-        url('@test*1/stuff#2', channel_sequence='1', stream_claim_id='2', channel_name='@test', stream_name='stuff', strictly=False)
         # unicode regex edges
         _url = lambda name: url(name, stream_name=name)
         _url('\uD799')
@@ -111,10 +108,8 @@ class TestURLParsing(unittest.TestCase):
         fail("lbry://test@")
         fail("lbry://tes@t")
         fail(f"lbry://test:1#{claim_id}")
-        fail("lbry://test*0")
         fail("lbry://test$0")
         fail("lbry://test/path")
-        fail("lbry://@test1*1ab/fakepath")
         fail("lbry://test:1:1:1")
         fail("whatever/lbry://test")
         fail("lbry://lbry://test")
@@ -122,5 +117,4 @@ class TestURLParsing(unittest.TestCase):
         fail("lbry://abc:0x123")
         fail("lbry://abc:0x123/page")
         fail("lbry://@test1#ABCDEF/fakepath")
-        fail("test*0001")
         fail("lbry://@test1$1/fakepath?arg1&arg2&arg3")


### PR DESCRIPTION
fixes #3084 