### PR TITLE
docs: fix simple typo, thsoe -> those

### DIFF
--- a/tests/integration/blockchain/test_wallet_server_sessions.py
+++ b/tests/integration/blockchain/test_wallet_server_sessions.py
@@ -38,7 +38,7 @@ class TestSessions(IntegrationTestCase):
         self.assertEqual(lbry.__version__, info['server_version'])
 
     async def test_client_errors(self):
-        # Goal is ensuring thsoe are raised and not trapped accidentally
+        # Goal is ensuring those are raised and not trapped accidentally
         with self.assertRaisesRegex(Exception, 'not a valid address'):
             await self.ledger.network.get_history('of the world')
         with self.assertRaisesRegex(Exception, 'rejected by network rules.*TX decode failed'):


### PR DESCRIPTION
There is a small typo in tests/integration/blockchain/test_wallet_server_sessions.py.

Should read `those` rather than `thsoe`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md