### PR TITLE
removed `connection_status` field from the `status` command, use `wallet.connected` instead to determine if SDK is connected to a wallet server

### DIFF
--- a/lbry/utils.py
+++ b/lbry/utils.py
@@ -105,10 +105,6 @@ def check_connection(server="lbry.com", port=80, timeout=5) -> bool:
         return False
 
 
-async def async_check_connection(server="lbry.com", port=80, timeout=1) -> bool:
-    return await asyncio.get_event_loop().run_in_executor(None, check_connection, server, port, timeout)
-
-
 def random_string(length=10, chars=string.ascii_lowercase):
     return ''.join([random.choice(chars) for _ in range(length)])
 

--- a/tests/integration/other/test_cli.py
+++ b/tests/integration/other/test_cli.py
@@ -36,4 +36,4 @@ class CLIIntegrationTest(AsyncioTestCase):
         with contextlib.redirect_stdout(actual_output):
             cli.main(["--api", "localhost:5299", "status"])
         actual_output = actual_output.getvalue()
-        self.assertIn("connection_status", actual_output)
+        self.assertIn("is_running", actual_output)


### PR DESCRIPTION
backwards-incompatible: removes `connection_status` field from `status` API call. see PR link for details.

how to differentiate the states of lbrynet `status` wallet connection

- if `wallet.connected` has a value, then it's connected.
- otherwise:
  - if `startup_status.wallet` is false, then sdk is still connecting to wallet servers. it will never stop trying till it connects.
  - if `startup_status.wallet` is true, then the sdk used to have a wallet server connection but that dropped and it's still trying to reconnect
 
fixes #3196 
related to #3158