### PR TITLE
Documents result structure enumerated values for connection_status code

### DIFF
--- a/lbry/extras/daemon/daemon.py
+++ b/lbry/extras/daemon/daemon.py
@@ -875,7 +875,7 @@ class Daemon(metaclass=JSONRPCServerType):
                     'wallet': (bool),
                 },
                 'connection_status': {
-                    'code': (str) connection status code,
+                    'code': (str) "connected" | "network_connection",
                     'message': (str) connection status message
                 },
                 'blockchain_headers': {


### PR DESCRIPTION
I did not attach a regenerated api.json to this commit, as it seems to be out of sync with other changes, or at the very least produces significantly different results (generally in curl examples).  Perhaps that is expected.  I am unfamiliar with the process (perhaps it is manual for small changes)?