### PR TITLE
finished switch from using hash `#` in URLs to a colon `:` when delineating claim name from claim id

### DIFF
--- a/lbry/wallet/server/db/canonical.py
+++ b/lbry/wallet/server/db/canonical.py
@@ -15,7 +15,7 @@ class FindShortestID:
 
     def finalize(self):
         if self.short_id:
-            return '#'+self.short_id
+            return ':'+self.short_id
 
     @classmethod
     def factory(cls):

--- a/lbry/wallet/server/db/writer.py
+++ b/lbry/wallet/server/db/writer.py
@@ -47,8 +47,8 @@ class SQLDB:
             expiration_height integer not null,
             release_time integer not null,
 
-            short_url text not null, -- normalized#shortest-unique-claim_id
-            canonical_url text, -- channel's-short_url/normalized#shortest-unique-claim_id-within-channel
+            short_url text not null, -- normalized:shortest-unique-claim_id
+            canonical_url text, -- channel's-short_url/normalized:shortest-unique-claim_id-within-channel
 
             title text,
             author text,
@@ -452,7 +452,7 @@ class SQLDB:
                     CASE WHEN :height >= 137181 THEN :height+2102400 ELSE :height+262974 END,
                     :claim_name||COALESCE(
                         (SELECT shortest_id(claim_id, :claim_id) FROM claim WHERE normalized = :normalized),
-                        '#'||substr(:claim_id, 1, 1)
+                        ':'||substr(:claim_id, 1, 1)
                     )
                 )""", claims)
 
@@ -665,7 +665,7 @@ class SQLDB:
                                  WHERE other_claim.signature_valid = 1 AND
                                        other_claim.channel_hash = :channel_hash AND
                                        other_claim.normalized = claim.normalized),
-                                '#'||substr(claim_id, 1, 1)
+                                ':'||substr(claim_id, 1, 1)
                             )
                     END
                 WHERE claim_hash=:claim_hash;

--- a/lbry/wallet/transaction.py
+++ b/lbry/wallet/transaction.py
@@ -384,7 +384,7 @@ class Output(InputOutput):
     @property
     def permanent_url(self) -> str:
         if self.script.is_claim_involved:
-            return f"lbry://{self.claim_name}#{self.claim_id}"
+            return f"lbry://{self.claim_name}:{self.claim_id}"
         raise ValueError('No claim associated.')
 
     @property

--- a/tests/integration/blockchain/test_claim_commands.py
+++ b/tests/integration/blockchain/test_claim_commands.py
@@ -1430,7 +1430,7 @@ class StreamCommands(ClaimTestCase):
         self.assertEqual(1, blocked['total'])
         self.assertEqual(1, len(blocked['channels']))
         self.assertEqual(1, blocked['channels'][0]['blocked'])
-        self.assertTrue(blocked['channels'][0]['channel']['short_url'].startswith('lbry://@filtering#'))
+        self.assertTrue(blocked['channels'][0]['channel']['short_url'].startswith('lbry://@filtering:'))
 
         # same search, but details omitted by 'no_totals'
         last_result = result
@@ -1444,7 +1444,7 @@ class StreamCommands(ClaimTestCase):
         self.assertEqual(1, filtered['total'])
         self.assertEqual(1, len(filtered['channels']))
         self.assertEqual(1, filtered['channels'][0]['blocked'])
-        self.assertTrue(filtered['channels'][0]['channel']['short_url'].startswith('lbry://@filtering#'))
+        self.assertTrue(filtered['channels'][0]['channel']['short_url'].startswith('lbry://@filtering:'))
 
         # same search, but details omitted by 'no_totals'
         last_result = result
@@ -1474,7 +1474,7 @@ class StreamCommands(ClaimTestCase):
         error = (await self.resolve('lbry://@some_channel/bad_content'))['error']
         self.assertEqual(error['name'], 'BLOCKED')
         self.assertTrue(error['text'].startswith("Resolve of 'lbry://@some_channel/bad_content' was censored"))
-        self.assertTrue(error['censor']['short_url'].startswith('lbry://@blocking#'))
+        self.assertTrue(error['censor']['short_url'].startswith('lbry://@blocking:'))
 
         # a filtered/blocked channel impacts all content inside it
         bad_channel_id = self.get_claim_id(
@@ -1502,7 +1502,7 @@ class StreamCommands(ClaimTestCase):
         self.assertEqual(3, filtered['total'])
         self.assertEqual(1, len(filtered['channels']))
         self.assertEqual(3, filtered['channels'][0]['blocked'])
-        self.assertTrue(filtered['channels'][0]['channel']['short_url'].startswith('lbry://@filtering#'))
+        self.assertTrue(filtered['channels'][0]['channel']['short_url'].startswith('lbry://@filtering:'))
 
         # same search, but details omitted by 'no_totals'
         last_result = result

--- a/tests/integration/blockchain/test_claim_commands.py
+++ b/tests/integration/blockchain/test_claim_commands.py
@@ -160,11 +160,11 @@ class ClaimSearchCommand(ClaimTestCase):
         # three streams in channel, zero streams in abandoned channel
         claims = [three, two, signed]
         await self.assertFindsClaims(claims, channel_ids=[self.channel_id])
-        await self.assertFindsClaims(claims, channel=f"@abc#{self.channel_id}")
+        await self.assertFindsClaims(claims, channel=f"@abc:{self.channel_id}")
         await self.assertFindsClaims([], channel=f"@inexistent")
         await self.assertFindsClaims([three, two, signed2, signed], channel_ids=[channel_id2, self.channel_id])
         await self.channel_abandon(claim_id=self.channel_id)
-        await self.assertFindsClaims([], channel=f"@abc#{self.channel_id}", valid_channel_signature=True)
+        await self.assertFindsClaims([], channel=f"@abc:{self.channel_id}", valid_channel_signature=True)
         await self.assertFindsClaims([], channel_ids=[self.channel_id], valid_channel_signature=True)
         await self.assertFindsClaims([signed2], channel_ids=[channel_id2], valid_channel_signature=True)
         # pass `invalid_channel_signature=False` to catch a bug in argument processing

--- a/tests/integration/blockchain/test_resolve_command.py
+++ b/tests/integration/blockchain/test_resolve_command.py
@@ -132,8 +132,8 @@ class ResolveCommand(BaseResolveTestCase):
         channel_id = self.get_claim_id(
             await self.channel_create('@abc', '1.1', allow_duplicate_name=True))
         await self.assertResolvesToClaimId(f'@abc', channel_id)
-        await self.assertResolvesToClaimId(f'@abc#{channel_id[:10]}', channel_id)
-        await self.assertResolvesToClaimId(f'@abc#{channel_id}', channel_id)
+        await self.assertResolvesToClaimId(f'@abc:{channel_id[:10]}', channel_id)
+        await self.assertResolvesToClaimId(f'@abc:{channel_id}', channel_id)
         channel = (await self.claim_search(claim_id=channel_id))[0]
         await self.assertResolvesToClaimId(channel['short_url'], channel_id)
         await self.assertResolvesToClaimId(channel['canonical_url'], channel_id)
@@ -182,7 +182,7 @@ class ResolveCommand(BaseResolveTestCase):
         response = await self.resolve('lbry://on-channel-claim')
         self.assertFalse(response['is_channel_signature_valid'])
         self.assertEqual({'channel_id': abandoned_channel_id}, response['signing_channel'])
-        direct_uri = 'lbry://on-channel-claim#' + orphan_claim_id
+        direct_uri = 'lbry://on-channel-claim:' + orphan_claim_id
         response = await self.resolve(direct_uri)
         self.assertFalse(response['is_channel_signature_valid'])
         self.assertEqual({'channel_id': abandoned_channel_id}, response['signing_channel'])


### PR DESCRIPTION
fixes #3256