### PR TITLE
Minor fix suggestion for issue #3240

### DIFF
--- a/lbry/file/source_manager.py
+++ b/lbry/file/source_manager.py
@@ -132,7 +132,7 @@ class SourceManager:
         else:
             streams = list(self._sources.values())
         if sort_by:
-            streams.sort(key=lambda s: getattr(s, sort_by))
+            streams.sort(key=lambda s: getattr(s, sort_by) or "")
             if reverse:
                 streams.reverse()
         return streams


### PR DESCRIPTION
L135: If `getattr()` returns `None`, use `""` instead to avoid error in issue #3240