### PR TITLE
When using a version of Python >= 3.8 on linux, plyvel fails to install (solution is to update to newer version of plyvel)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ with open(os.path.join(BASE, 'README.md'), encoding='utf-8') as fh:
 
 PLYVEL = []
 if sys.platform.startswith('linux'):
-    PLYVEL.append('plyvel==1.0.5')
+    PLYVEL.append('plyvel==1.3.0')
 
 setup(
     name=__name__,


### PR DESCRIPTION
It is only as of version 1.3.0 that plyvel supports Python 3.9, however `setup.py` requires the following version:
```python
PLYVEL = []
if sys.platform.startswith('linux'):
    PLYVEL.append('plyvel==1.0.5')
```

I suggest changing this to 1.3.0. The only downside to this that I am aware of is that plyvel 1.3.0 drops support for Python version <= 3.5 (more info [here](https://plyvel.readthedocs.io/en/latest/news.html)), but this shouldn't be an issue.