### PR TITLE
INSTALL.md: add `libleveldb-dev` to required packages

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -72,6 +72,13 @@ To install on Linux/Mac:
 
 To verify your installation, `which lbrynet` should return a path inside of the `lbry-venv` folder created by the `python3.7 -m venv lbry-venv` command.
 
+To exit the virtual environment simply use the command `deactivate`.
+
+When developing, remember to enter the environment again.
+```
+source lbry-venv/bin/activate
+```
+
 ### Windows
 
 To install on Windows:
@@ -116,5 +123,9 @@ To run the unit and integration tests from the repo directory:
 To start the API server:
     `lbrynet start`
 
+When developing, we can start the server interactively.
+```
+python lbry/extras/cli.py start
+```
 
 Happy hacking!

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -36,7 +36,7 @@ On Ubuntu (16.04 minimum, we recommend 18.04), install the following:
 ```
 sudo add-apt-repository ppa:deadsnakes/ppa
 sudo apt-get update
-sudo apt-get install build-essential python3.7 python3.7-dev git python3.7-venv libssl-dev python-protobuf
+sudo apt-get install build-essential python3.7 python3.7-dev git python3.7-venv libssl-dev python-protobuf libleveldb-dev
 ```
 
 On Raspbian, you will also need to install `python-pyparsing`.

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -9,9 +9,19 @@ Here's a video walkthrough of this setup, which is itself hosted by the LBRY net
 
 ## Prerequisites
 
-Running `lbrynet` from source requires Python 3.7 or higher. Get the installer for your OS [here](https://www.python.org/downloads/release/python-370/).
+Running `lbrynet` from source requires Python 3.7. Get the installer for your OS [here](https://www.python.org/downloads/release/python-370/).
 
-After installing python 3, you'll need to install some additional libraries depending on your operating system.
+After installing python 3.7, you'll need to install some additional libraries depending on your operating system.
+
+Because of [issue #2769](https://github.com/lbryio/lbry-sdk/issues/2769)
+at the moment the `lbrynet` daemon will only work correctly with Python 3.7.
+If Python 3.8 is used, the daemon will start but the RPC server
+may not accept messages, returning the following:
+```
+Could not connect to daemon. Are you sure it's running?
+```
+
+Python 3.9 does not work either, as it fails in the compilation of `plyvel`.
 
 ### macOS
 
@@ -31,13 +41,17 @@ Assistance installing Python3: https://docs.python-guide.org/starting/install3/o
 
 ### Linux
 
-On Ubuntu (16.04 minimum, we recommend 18.04), install the following:
+On Ubuntu (we recommend 18.04 or 20.04), install the following:
 
 ```
 sudo add-apt-repository ppa:deadsnakes/ppa
 sudo apt-get update
 sudo apt-get install build-essential python3.7 python3.7-dev git python3.7-venv libssl-dev python-protobuf libleveldb-dev
 ```
+
+The `deadsnakes` personal package archive (PPA) provides Python 3.7
+for those Ubuntu distributions that no longer have it in their
+official repositories.
 
 On Raspbian, you will also need to install `python-pyparsing`.
 


### PR DESCRIPTION
With the provided instructions in `INSTALL.md`, the `make` command may result in errors:
```
    plyvel/_plyvel.cpp:589:10: fatal error: leveldb/db.h: No such file or directory
      589 | #include "leveldb/db.h"
          |          ^~~~~~~~~~~~~~
    compilation terminated.
    error: command 'x86_64-linux-gnu-gcc' failed with exit status 1

...
Failed to build plyvel prometheus-client pylru pyyaml.
```

The required header files are contained in the `libleveldb-dev` package in Ubuntu 18.04 and 20.04 at least.

After installing this package the compilation proceeds successfully.
In some cases `make` may have to be run twice.

This addresses issue #3281.

----

Also add more information on entering and exiting the virtual environment.
```
deactivate  # leave
source lbry-venv/bin/activate  # enter
```

To test the daemon interactively, we can run the `cli.py` program.
```
python lbry/extras/cli.py start
```

----

Because of issue #2769 at the moment the `lbrynet` daemon will only work correctly with Python 3.7.

If Python 3.8+ is used, the daemon will start but the RPC server may not accept messages,