### PR TITLE
script/checktrie: fix the import to `SQLDB`

### DIFF
--- a/scripts/checktrie.py
+++ b/scripts/checktrie.py
@@ -2,7 +2,7 @@ import sys
 import asyncio
 from binascii import hexlify
 
-from lbry.wallet.server.db import SQLDB
+from lbry.wallet.server.db.writer import SQLDB
 from lbry.wallet.server.coin import LBC
 from lbry.wallet.server.daemon import Daemon
 


### PR DESCRIPTION
This is nothing special, it just allows the script to run without throwing an error on import.