### PR TITLE
make get_or_create_usable_address respect the generator lock, avoiding race conditions when getting an unused address while generating them

### DIFF
--- a/lbry/wallet/account.py
+++ b/lbry/wallet/account.py
@@ -96,7 +96,8 @@ class AddressManager:
         return [r['address'] for r in records]
 
     async def get_or_create_usable_address(self) -> str:
-        addresses = await self.get_addresses(only_usable=True, limit=10)
+        async with self.address_generator_lock:
+            addresses = await self.get_addresses(only_usable=True, limit=10)
         if addresses:
             return random.choice(addresses)
         addresses = await self.ensure_address_gap()


### PR DESCRIPTION
closes #2837 