### PR TITLE
cli.py: print `ClientConnectionError` exception

### DIFF
--- a/lbry/extras/cli.py
+++ b/lbry/extras/cli.py
@@ -37,7 +37,8 @@ async def execute_command(conf, method, params, callback=display):
                         return callback(data['error'])
                 except Exception as e:
                     log.exception('Could not process response from server:', exc_info=e)
-        except aiohttp.ClientConnectionError:
+        except aiohttp.ClientConnectionError as cce:
+            log.exception("Exception: ", exc_info=cce)
             print("Could not connect to daemon. Are you sure it's running?")
 
 


### PR DESCRIPTION
As reported in issue #2769 and #3358, the `lbrynet` daemon doesn't respond correctly when it is compiled against Python 3.8+; it only work correctly with Python 3.7.

In this case it will raise the exception `aiohttp.ClientConnectionError`.

We want to print this exception for the future to know what went wrong and be able to troubleshoot.