### PR TITLE
improved error handling when fetching exchange rate from UPbit

### DIFF
--- a/lbry/extras/daemon/exchange_rate_manager.py
+++ b/lbry/extras/daemon/exchange_rate_manager.py
@@ -186,7 +186,7 @@ class UPbitBTCFeed(MarketFeed):
     params = {"markets": "BTC-LBC"}
 
     def get_rate_from_response(self, json_response):
-        if len(json_response) != 1 or 'trade_price' not in json_response[0]:
+        if "error" in json_response or len(json_response) != 1 or 'trade_price' not in json_response[0]:
             raise InvalidExchangeRateResponseError(self.name, 'result not found')
         return 1.0 / float(json_response[0]['trade_price'])
 


### PR DESCRIPTION
If the error is not handled, the running daemon will continuously print the following error message:
```
Traceback (most recent call last):
  File "lbry/extras/daemon/exchange_rate_manager.py", line 77, in get_rate
  File "lbry/extras/daemon/exchange_rate_manager.py", line 189, in get_rate_from_response
KeyError: 0
```

This started happening when the UPBit exchange decided to delist the LBC coin.

Normally `json_response` should be a dictionary, not a list, so `json_response[0]` causes an error.

By checking for the `'error'` key, we can raise the proper exception.

Once this is done, the message will be a warning, not a traceback.
```
WARNING  lbry.extras.daemon.exchange_rate_manager:92: Failed to get exchange rate from UPbit: result not found
```

This addresses the second error in #3287.