### PR TITLE
file_manager: trap the exception if the claim is not a stream

### DIFF
--- a/lbry/error/README.md
+++ b/lbry/error/README.md
@@ -35,6 +35,7 @@ Code | Name | Message
 111 | GenericInputValue | The value '{value}' for argument '{argument}' is not valid.
 112 | InputValueIsNone | None or null is not valid value for argument '{argument}'.
 113 | ConflictingInputValue | Only '{first_argument}' or '{second_argument}' is allowed, not both.
+114 | InvalidStreamURL | Invalid LBRY stream URL: '{url}' -- When an URL cannot be downloaded, such as '@Channel/' or a collection
 **2xx** | Configuration | Configuration errors.
 201 | ConfigWrite | Cannot write configuration file '{path}'. -- When writing the default config fails on startup, such as due to permission issues.
 202 | ConfigRead | Cannot find provided configuration file '{path}'. -- Can't open the config file user provided via command line args.

--- a/lbry/error/__init__.py
+++ b/lbry/error/__init__.py
@@ -84,6 +84,16 @@ class ConflictingInputValueError(InputValueError):
         super().__init__(f"Only '{first_argument}' or '{second_argument}' is allowed, not both.")
 
 
+class InvalidStreamURLError(InputValueError):
+    """
+    When an URL cannot be downloaded, such as '@Channel/' or a collection
+    """
+
+    def __init__(self, url):
+        self.url = url
+        super().__init__(f"Invalid LBRY stream URL: '{url}'")
+
+
 class ConfigurationError(BaseError):
     """
     Configuration errors.

--- a/lbry/file/file_manager.py
+++ b/lbry/file/file_manager.py
@@ -114,6 +114,11 @@ class FileManager:
             resolved_time = self.loop.time() - start_time
             await self.storage.save_claim_from_output(self.wallet_manager.ledger, txo)
 
+            if claim.is_collection:
+                raise InvalidStreamURLError(uri)
+            if not claim.is_stream:
+                raise InvalidStreamURLError(uri)
+
             ####################
             # update or replace
             ####################


### PR DESCRIPTION
If `claim` is not a stream, the line `claim.stream.source.bt_infohash` will raise a `ValueError` exception because `claim.stream` does not contain a valid object.

This will happen if we try to download a claim that is in fact a `collection` (a playlist).
```
lbrynet get lbry://@something#e/My-New-List#f
```

Since at the moment we don't trap this exception, it prints the entire trace of the exception.
```
Traceback (most recent call last):
  File "/opt/git/lbry-sdk/lbry/file/file_manager.py", line 117, in download_from_uri
    if claim.stream.source.bt_infohash:
  File "/opt/git/lbry-sdk/lbry/schema/claim.py", line 55, in stream
    return Stream(self)
  File "/opt/git/lbry-sdk/lbry/schema/claim.py", line 108, in __init__
    self.message = self.claim.get_message(self.claim_type)
  File "/opt/git/lbry-sdk/lbry/schema/claim.py", line 46, in get_message
    raise ValueError(f'Claim is not a {type_name}.')
```

Therefore we trap this `ValueError` to avoid showing the entire trace.
We don't do anything with the exception, we just raise it again so that it is handled by the calling code `daemon.jsonrpc_get`.

Then it will show an appropriate message.
```
WARNING  lbry.extras.daemon.daemon:1106: Error downloading lbry://@something#e/My-New-List#f: Claim is not a stream.
```