### PR TITLE
fix error when using `--claim_id` with `lbrynet claim search`

### DIFF
--- a/lbry/extras/daemon/daemon.py
+++ b/lbry/extras/daemon/daemon.py
@@ -2479,6 +2479,8 @@ class Daemon(metaclass=JSONRPCServerType):
         Returns: {Paginated[Output]}
         """
         wallet = self.wallet_manager.get_wallet_or_default(kwargs.pop('wallet_id', None))
+        if "claim_ids" in kwargs and not kwargs["claim_id"]:
+            kwargs.pop("claim_ids")
         if {'claim_id', 'claim_ids'}.issubset(kwargs):
             raise ValueError("Only 'claim_id' or 'claim_ids' is allowed, not both.")
         if kwargs.pop('valid_channel_signature', False):


### PR DESCRIPTION
For some reason, when using `claim_search` with `--claim_id`, the arguments dictionary will also contain `claim_ids` with an empty list, even if we didn't specify it.
```
lbrynet claim search --claim_id=8945573bcfcb7f8276187dfbb93545eac4ebf71a
```
```
{
...
    "name": "ValueError",
    "traceback": [
      "Traceback (most recent call last):",
      "  File \"lbry/extras/daemon/daemon.py\", line 693, in _process_rpc_call",
      "  File \"lbry/extras/daemon/daemon.py\", line 2483, in jsonrpc_claim_search",
      "ValueError: Only 'claim_id' or 'claim_ids' is allowed, not both.",
      ""
    ]
  },
  "message": "Only 'claim_id' or 'claim_ids' is allowed, not both."
}
```

Using both `claim_id` and `claim_ids` will raise a `ValueError` exception so the daemon won't return a valid result even if the claim ID is in fact valid.

So if `claim_id` exists, we need to discard `claim_ids` if it is empty, before proceeding with the rest of the code.

On the other hand, if `claim_ids` is used, and `claim_id` is absent, there will be no problem as `claim_id` won't be added to the dictionary.
```
lbrynet claim search --claim_ids=8945573bcfcb7f8276187dfbb93545eac4ebf71a
```

Related #2342