### PR TITLE
daemon: fix `claim_search`; previous fix #3367 was incomplete

### DIFF
--- a/lbry/extras/daemon/daemon.py
+++ b/lbry/extras/daemon/daemon.py
@@ -2479,7 +2479,7 @@ class Daemon(metaclass=JSONRPCServerType):
         Returns: {Paginated[Output]}
         """
         wallet = self.wallet_manager.get_wallet_or_default(kwargs.pop('wallet_id', None))
-        if "claim_ids" in kwargs and not kwargs["claim_id"]:
+        if "claim_ids" in kwargs and not kwargs["claim_ids"]:
             kwargs.pop("claim_ids")
         if {'claim_id', 'claim_ids'}.issubset(kwargs):
             raise ValueError("Only 'claim_id' or 'claim_ids' is allowed, not both.")


### PR DESCRIPTION
The previous pull request #3367 was merged but had a small mistake. It should be `kwargs["claim_ids"]` instead of `kwargs["claim_id"]`.

----

This solves the following error:
```
lbrynet claim search helplbrysavecrypto
```
```
{
  "code": -32500,
  "data": {
    "args": [],
    "command": "claim_search",
    "kwargs": {
      "all_languages": [],
      "all_locations": [],
      "all_tags": [],
      "any_languages": [],
      "any_locations": [],
      "any_tags": [],
      "channel_ids": [],
      "claim_ids": [],
      "has_channel_signature": false,
      "has_no_source": false,
      "has_source": false,
      "include_is_my_output": false,
      "include_purchase_receipt": false,
      "invalid_channel_signature": false,
      "is_controlling": false,
      "media_types": [],
      "name": "helplbrysavecrypto",
      "no_totals": false,
      "not_channel_ids": [],
      "not_languages": [],
      "not_locations": [],
      "not_tags": [],
      "order_by": [],
      "remove_duplicates": false,
      "stream_types": [],
      "valid_channel_signature": false
    },
    "name": "KeyError",
    "traceback": [
      "Traceback (most recent call last):",
      "  File \"/opt/git/lbry-sdk/lbry/extras/daemon/daemon.py\", line 693, in _process_rpc_call",
      "    result = await result",
      "  File \"/opt/git/lbry-sdk/lbry/extras/daemon/daemon.py\", line 2482, in jsonrpc_claim_search",
      "    if \"claim_ids\" in kwargs and not kwargs[\"claim_id\"]:",
      "KeyError: 'claim_id'",
      ""
    ]
  },
  "message": "'claim_id'"
}
```