### PR TITLE
Daemon.jsonrpc_claim_search: `page_size` is no longer a minimum value

### DIFF
--- a/lbry/extras/daemon/daemon.py
+++ b/lbry/extras/daemon/daemon.py
@@ -2507,7 +2507,7 @@ class Daemon(metaclass=JSONRPCServerType):
             kwargs['signature_valid'] = 0
         if 'has_no_source' in kwargs:
             kwargs['has_source'] = not kwargs.pop('has_no_source')
-        page_num, page_size = abs(kwargs.pop('page', 1)), min(abs(kwargs.pop('page_size', DEFAULT_PAGE_SIZE)), 50)
+        page_num, page_size = abs(kwargs.pop('page', 1)), max(abs(kwargs.pop('page_size', DEFAULT_PAGE_SIZE)), 50)
         kwargs.update({'offset': page_size * (page_num - 1), 'limit': page_size})
         txos, blocked, _, total = await self.ledger.claim_search(wallet.accounts, **kwargs)
         result = {

--- a/lbry/extras/daemon/daemon.py
+++ b/lbry/extras/daemon/daemon.py
@@ -2507,7 +2507,7 @@ class Daemon(metaclass=JSONRPCServerType):
             kwargs['signature_valid'] = 0
         if 'has_no_source' in kwargs:
             kwargs['has_source'] = not kwargs.pop('has_no_source')
-        page_num, page_size = abs(kwargs.pop('page', 1)), max(abs(kwargs.pop('page_size', DEFAULT_PAGE_SIZE)), 50)
+        page_num, page_size = abs(kwargs.pop('page', 1)), abs(kwargs.pop('page_size', DEFAULT_PAGE_SIZE))
         kwargs.update({'offset': page_size * (page_num - 1), 'limit': page_size})
         txos, blocked, _, total = await self.ledger.claim_search(wallet.accounts, **kwargs)
         result = {


### PR DESCRIPTION
This addresses issue #3381, and partially #3365.

Currently with `lbrynet claim search` when `--page_size` is specified, it will use the minimum of this value or 50. So, if it's `--page_size=1000` it will use 50.

If `--page_size` is omitted, it will use the minimum of `DEFAULT_PAGE_SIZE` (normally 20) or 50.

So, instead of using `min` we use `max`, meaning that a larger `page_size` value will be used. This will allow us to fit as many elements as possible in the claim search.

However, there is still a separate bug, issue #3365, which limits the total results to 1000, no matter how big `page_size` is.