### PR TITLE
schema/url: raise `ResolveError` if the URL is invalid

### DIFF
--- a/lbry/file/file_manager.py
+++ b/lbry/file/file_manager.py
@@ -244,7 +244,7 @@ class FileManager:
             raise error
         except Exception as err:  # forgive data timeout, don't delete stream
             expected = (DownloadSDTimeoutError, DownloadDataTimeoutError, InsufficientFundsError,
-                        KeyFeeAboveMaxAllowedError)
+                        KeyFeeAboveMaxAllowedError, ResolveError)
             if isinstance(err, expected):
                 log.warning("Failed to download %s: %s", uri, str(err))
             elif isinstance(err, asyncio.CancelledError):

--- a/lbry/schema/url.py
+++ b/lbry/schema/url.py
@@ -1,6 +1,7 @@
 import re
 import unicodedata
 from typing import NamedTuple, Tuple
+from lbry.error import ResolveError
 
 
 def _create_url_regex():
@@ -111,7 +112,7 @@ class URL(NamedTuple):
         match = re.match(URL_REGEX, url)
 
         if match is None:
-            raise ValueError('Invalid LBRY URL')
+            raise ResolveError('Invalid LBRY URL')
 
         segments = {}
         parts = match.groupdict()

--- a/tests/unit/schema/test_url.py
+++ b/tests/unit/schema/test_url.py
@@ -1,7 +1,7 @@
 import unittest
 
 from lbry.schema.url import URL
-
+from lbry.error import ResolveError
 
 claim_id = "63f2da17b0d90042c559cc73b6b17f853945c43e"
 
@@ -36,7 +36,7 @@ class TestURLParsing(unittest.TestCase):
                     )
 
     def _fail_url(self, url):
-        with self.assertRaisesRegex(ValueError, 'Invalid LBRY URL'):
+        with self.assertRaisesRegex(ResolveError, 'Invalid LBRY URL'):
             URL.parse(url)
 
     def test_parser_valid_urls(self):


### PR DESCRIPTION
This is similar to #3364.

When using `lbrynet get URL`, if the URL is not a valid URL the function `url.URL.parse` will raise a `ValueError` exception which will produce a whole backtrace.

For example, this is the case if we provide a channel name with a forward slash but without a stream name.
```
lbrynet get @Non-existing/
```

```
Traceback (most recent call last):
  File "/opt/git/lbry-sdk/lbry/file/file_manager.py", line 84, in download_from_uri
    if not URL.parse(uri).has_stream:
  File "/opt/git/lbry-sdk/lbry/schema/url.py", line 114, in parse
    raise ValueError('Invalid LBRY URL')
ValueError: Invalid LBRY URL
WARNING  lbry.extras.daemon.daemon:1106: Error downloading @Non-existing/: Invalid LBRY URL
```

Now we raise `ResolveError` which can be trapped in the upper functions that use `url.URL.parse` such as `FileManager.download_from_uri`. The traceback won't be shown.

```
WARNING  lbry.file.file_manager:249: Failed to download @Non-existing/: Failed to resolve 'Invalid LBRY URL'.
WARNING  lbry.extras.daemon.daemon:1106: Error downloading @Non-existing/: Failed to resolve 'Invalid LBRY URL'.
```

----

The `FileManager` class raises `ResolveError` in many situations but I don't know if this is the best exception to throw. Maybe a new exception should be defined like `NotDownloadableError` derived from `WalletError` in `lbry/error`.