### PR TITLE
file_manager: handle the response better when a claim is not found

### DIFF
--- a/lbry/file/file_manager.py
+++ b/lbry/file/file_manager.py
@@ -103,6 +103,8 @@ class FileManager:
             if not resolved_result or uri not in resolved_result:
                 raise ResolveError(f"Failed to resolve stream at '{uri}'")
             txo = resolved_result[uri]
+            if not hasattr(txo, "claim") and "error" in txo and "text" in txo["error"]:
+                raise ResolveError(f"{txo['error']['text']}")
             if isinstance(txo, dict):
                 raise ResolveError(f"Failed to resolve stream at '{uri}': {txo}")
             claim = txo.claim
@@ -244,7 +246,7 @@ class FileManager:
             raise error
         except Exception as err:  # forgive data timeout, don't delete stream
             expected = (DownloadSDTimeoutError, DownloadDataTimeoutError, InsufficientFundsError,
-                        KeyFeeAboveMaxAllowedError)
+                        KeyFeeAboveMaxAllowedError, ResolveError)
             if isinstance(err, expected):
                 log.warning("Failed to download %s: %s", uri, str(err))
             elif isinstance(err, asyncio.CancelledError):


### PR DESCRIPTION
This is similar to #3364 and #3396.

When using `lbrynet get URL`, if the URL does not exist it will raise a `ResolveError` exception which will produce a long backtrace.

For example
```
lbrynet get Non-existing
```

```
Traceback (most recent call last):
  File "/opt/git/lbry-sdk/lbry/file/file_manager.py", line 107, in download_from_uri
    raise ResolveError(f"Failed to resolve stream at '{uri}': {txo}")
lbry.error.ResolveError: Failed to resolve 'Failed to resolve stream at 'Non-existing': {'error': {'name': 'NOT_FOUND', 'text': 'Could not find claim at "Non-existing".'}}'.
WARNING  lbry.extras.daemon.daemon:1106: Error downloading Non-existing: Failed to resolve 'Failed to resolve stream at 'Non-existing': {'error': {'name': 'NOT_FOUND', 'text': 'Could not find claim at "Non-existing".'}}'.
```

Not only that, the error message has a nested message inside so the full output is quite ugly.

-------------------------------------------------------------------

Now we will search for the `'error'` key in the response. If it is, and the `'text'` key is also present, we will raise `ResolveError` with the message stored in this text.

We will trap `ResolveError` so that the entire trace is not printed.

```
WARNING  lbry.file.file_manager:251: Failed to download Non-existing: Failed to resolve 'Could not find claim at "Non-existing".'.
WARNING  lbry.extras.daemon.daemon:1106: Error downloading Non-existing: Failed to resolve 'Could not find claim at "Non-existing".'.
```