### PR TITLE
jsonrpc_support_sum: remove the + signs from the docstring

### DIFF
--- a/lbry/extras/daemon/daemon.py
+++ b/lbry/extras/daemon/daemon.py
@@ -2311,9 +2311,9 @@ class Daemon(metaclass=JSONRPCServerType):
     async def jsonrpc_support_sum(self, claim_id, new_sdk_server, include_channel_content=False, **kwargs):
         """
         List total staked supports for a claim, grouped by the channel that signed the support.
-+
-+       If claim_id is a channel claim, you can use --include_channel_content to also include supports for
-+       content claims in the channel.
+
+        If claim_id is a channel claim, you can use --include_channel_content to also include supports for
+        content claims in the channel.
 
         !!!! NOTE: PAGINATION DOES NOT DO ANYTHING AT THE MOMENT !!!!!
 


### PR DESCRIPTION
Just a small change to the docstring of the `Daemon.jsonrpc_support_sum` method.

The lines start with `+` sings. These symbols came from 0a0ac3b7c9 and were probably added accidentally to the beginning of the line by copying and pasting some diffs.

The documentation may have to be recreated with `scripts/generate_json_api.py`

The [wiki documentation](https://github.com/lbryio/lbry-sdk/wiki/Daemon-docstring-formatting) points to a script (`scripts/gen_docs.py`) that no longer exists so the information should be updated as well.
