### PR TITLE
Daemon.jsonrpc_getch: download the latest claims from a channel

### DIFF
--- a/lbry/extras/cli.py
+++ b/lbry/extras/cli.py
@@ -208,7 +208,7 @@ def get_argument_parser():
         group_parser = sub.add_parser(group_name, group_name=group_name, help=api['groups'][group_name])
         groups[group_name] = group_parser.add_subparsers(metavar='COMMAND')
 
-    nicer_order = ['stop', 'get', 'publish', 'resolve']
+    nicer_order = ['stop', 'get', 'getch', 'publish', 'resolve']
     for command_name in sorted(api['commands']):
         if command_name not in nicer_order:
             nicer_order.append(command_name)


### PR DESCRIPTION
This pull request should be merged after #3411, as it uses the new option `--download_repost` from `jsonrpc_get`.

---

This pull request implements a new method `Daemon.jsonrpc_getch` to download the latest claims from a particular channel. It will only pick those claims that have a `'source'`, which means it will ignore livestreams.

Download the 10 newest claims, not including livestreams nor reposts.
```
lbrynet getch @MyChannel --number=10
```

If a particular claim is in fact a repost, it won't be downloaded.

To resolve the reposts, and download the original claims, we can use the option `--download_repost`.

Download the 20 newest items, including any reposts.
```
lbrynet getch @MyChannel --number=20 --download_repost
```

Other options are those of the `get` method, such as `--download_directory`, `--timeout`, `--save_file`, and `--wallet_id`.