### PR TITLE
avoid [''] on peers list

### DIFF
--- a/lbry/wallet/server/env.py
+++ b/lbry/wallet/server/env.py
@@ -273,4 +273,4 @@ class Env:
             return self.PD_ON
 
     def extract_peer_hubs(self):
-        return [hub.strip() for hub in self.default('PEER_HUBS', '').split(',')]
+        return [hub.strip() for hub in self.default('PEER_HUBS', '').split(',') if hub.strip()]


### PR DESCRIPTION
this fixes compat with lbry vault and some electrum clients that aren't expecting `['']` on peer list, which is expected when federation is completely disabled.