### PR TITLE
Daemon.jsonrpc_file_delete: new `--what` parameter to control what to delete

### DIFF
--- a/lbry/file/file_manager.py
+++ b/lbry/file/file_manager.py
@@ -297,6 +297,6 @@ class FileManager:
         """
         return sum((manager.get_filtered(*args, **kwargs) for manager in self.source_managers.values()), [])
 
-    async def delete(self, source: ManagedDownloadSource, delete_file=False):
+    async def delete(self, source: ManagedDownloadSource, delete_file=False, delete_blobs=True):
         for manager in self.source_managers.values():
-            await manager.delete(source, delete_file)
+            await manager.delete(source, delete_file, delete_blobs)

--- a/lbry/file/source_manager.py
+++ b/lbry/file/source_manager.py
@@ -82,8 +82,10 @@ class SourceManager:
                      iv_generator: Optional[typing.Generator[bytes, None, None]] = None) -> ManagedDownloadSource:
         raise NotImplementedError()
 
-    async def delete(self, source: ManagedDownloadSource, delete_file: Optional[bool] = False):
-        self.remove(source)
+    async def delete(self, source: ManagedDownloadSource, delete_file: Optional[bool] = False,
+                     delete_source: Optional[bool] = True):
+        if delete_source:
+            self.remove(source)
         if delete_file and source.output_file_exists:
             os.remove(source.full_path)
 

--- a/lbry/stream/stream_manager.py
+++ b/lbry/stream/stream_manager.py
@@ -252,17 +252,19 @@ class StreamManager(SourceManager):
             self.reflect_stream(stream)
         return stream
 
-    async def delete(self, source: ManagedDownloadSource, delete_file: Optional[bool] = False):
+    async def delete(self, source: ManagedDownloadSource, delete_file: Optional[bool] = False,
+                     delete_source: Optional[bool] = True):
         if not isinstance(source, ManagedStream):
             return
-        if source.identifier in self.running_reflector_uploads:
-            self.running_reflector_uploads[source.identifier].cancel()
-        source.stop_tasks()
-        if source.identifier in self.streams:
-            del self.streams[source.identifier]
-        blob_hashes = [source.identifier] + [b.blob_hash for b in source.descriptor.blobs[:-1]]
-        await self.blob_manager.delete_blobs(blob_hashes, delete_from_db=False)
-        await self.storage.delete_stream(source.descriptor)
+        if delete_source:
+            if source.identifier in self.running_reflector_uploads:
+                self.running_reflector_uploads[source.identifier].cancel()
+            source.stop_tasks()
+            if source.identifier in self.streams:
+                del self.streams[source.identifier]
+            blob_hashes = [source.identifier] + [b.blob_hash for b in source.descriptor.blobs[:-1]]
+            await self.blob_manager.delete_blobs(blob_hashes, delete_from_db=False)
+            await self.storage.delete_stream(source.descriptor)
         if delete_file and source.output_file_exists:
             os.remove(source.full_path)
 

--- a/lbry/torrent/torrent_manager.py
+++ b/lbry/torrent/torrent_manager.py
@@ -122,8 +122,9 @@ class TorrentManager(SourceManager):
         super().stop()
         log.info("finished stopping the torrent manager")
 
-    async def delete(self, source: ManagedDownloadSource, delete_file: Optional[bool] = False):
-        await super().delete(source, delete_file)
+    async def delete(self, source: ManagedDownloadSource, delete_file: Optional[bool] = False,
+                     delete_source: Optional[bool] = True):
+        await super().delete(source, delete_file, delete_source)
         self.torrent_session.remove_torrent(source.identifier, delete_file)
 
     async def create(self, file_path: str, key: Optional[bytes] = None,


### PR DESCRIPTION
The `--what` parameter can be used to specify what to delete: the media file only, the blobs only, or both, deleting completely the downloaded stream.
```
lbrynet file delete --claim_name=my-claim --what=file
lbrynet file delete --claim_name=my-claim --what=blobs
lbrynet file delete --claim_name=my-claim --what=both
```

If no argument is used, this is equivalent to `--what=blobs`, which is the original behavior.
```
lbrynet file delete --claim_name=my-claim
```

The old argument, `--delete_from_download_dir`, works as `--what=both`.
```
lbrynet file delete --claim_name=my-claim --delete_from_download_dir
lbrynet file delete --claim_name=my-claim --what=both
```

Personally, I think we could deprecate completely this `--delete_from_download_dir` parameter.

----

In general, we extend the `delete` method of `FileManager` with the parameter `delete_blobs` to make the deletion of the blobs optional. This requires adding the argument `delete_source` to `StreamManager.delete`.

However, the `pylint` configuration complains and tells us that there is a mismatch in the arguments of the parent and children classes, so we also need to add the corresponding `delete_source` argument to `SourceManager.delete` and `TorrentManager.delete`.