### PR TITLE
fix typo in `file list` arguments list

### DIFF
--- a/docs/api.json
+++ b/docs/api.json
@@ -2657,7 +2657,7 @@
                         "is_required": false
                     },
                     {
-                        "name": "blobs_in_stream<blobs_in_stream>",
+                        "name": "blobs_in_stream",
                         "type": "int",
                         "description": "get file with matching blobs in stream",
                         "is_required": false

--- a/lbry/extras/daemon/daemon.py
+++ b/lbry/extras/daemon/daemon.py
@@ -2040,7 +2040,7 @@ class Daemon(metaclass=JSONRPCServerType):
             --channel_claim_id=<channel_claim_id>  : (str) get file with matching channel claim id(s)
             --channel_name=<channel_name>          : (str) get file with matching channel name
             --claim_name=<claim_name>              : (str) get file with matching claim name
-            --blobs_in_stream<blobs_in_stream>     : (int) get file with matching blobs in stream
+            --blobs_in_stream=<blobs_in_stream>    : (int) get file with matching blobs in stream
             --download_path=<download_path>        : (str) get file with matching download path
             --uploading_to_reflector=<uploading_to_reflector> : (bool) get files currently uploading to reflector
             --is_fully_reflected=<is_fully_reflected>         : (bool) get files that have been uploaded to reflector


### PR DESCRIPTION
This is necessary to produce the `docs/api.json` with correct information, and to be able to parse this file later on by other tools.

From
```
--blobs_in_stream<blobs_in_stream>
```
To
```
--blobs_in_stream=<blobs_in_stream> 
```