### PR TITLE
update default `tcp_port` to be the same as the default `udp_port`

### DIFF
--- a/lbry/conf.py
+++ b/lbry/conf.py
@@ -613,7 +613,7 @@ class Config(CLIConfig):
         "ports or have firewall rules you likely want to disable this.", True
     )
     udp_port = Integer("UDP port for communicating on the LBRY DHT", 4444, previous_names=['dht_node_port'])
-    tcp_port = Integer("TCP port to listen for incoming blob requests", 3333, previous_names=['peer_port'])
+    tcp_port = Integer("TCP port to listen for incoming blob requests", 4444, previous_names=['peer_port'])
     prometheus_port = Integer("Port to expose prometheus metrics (off by default)", 0)
     network_interface = String("Interface to use for the DHT and blob exchange", '0.0.0.0')
 

--- a/tests/integration/takeovers/test_resolve_command.py
+++ b/tests/integration/takeovers/test_resolve_command.py
@@ -153,11 +153,17 @@ class ResolveCommand(BaseResolveTestCase):
         await self.assertResolvesToClaimId(
             f'@abc#{colliding_claim_ids[0][:1]}', first_claim
         )
+        collision_depth = 0
+        for c1, c2 in zip(colliding_claim_ids[0], colliding_claim_ids[1]):
+            if c1 == c2:
+                collision_depth += 1
+            else:
+                break
         await self.assertResolvesToClaimId(f'@abc#{colliding_claim_ids[0][:2]}', colliding_claim_ids[0])
         await self.assertResolvesToClaimId(f'@abc#{colliding_claim_ids[0][:7]}', colliding_claim_ids[0])
         await self.assertResolvesToClaimId(f'@abc#{colliding_claim_ids[0][:17]}', colliding_claim_ids[0])
         await self.assertResolvesToClaimId(f'@abc#{colliding_claim_ids[0]}', colliding_claim_ids[0])
-        await self.assertResolvesToClaimId(f'@abc#{colliding_claim_ids[1][:3]}', colliding_claim_ids[1])
+        await self.assertResolvesToClaimId(f'@abc#{colliding_claim_ids[1][:collision_depth + 1]}', colliding_claim_ids[1])
         await self.assertResolvesToClaimId(f'@abc#{colliding_claim_ids[1][:7]}', colliding_claim_ids[1])
         await self.assertResolvesToClaimId(f'@abc#{colliding_claim_ids[1][:17]}', colliding_claim_ids[1])
         await self.assertResolvesToClaimId(f'@abc#{colliding_claim_ids[1]}', colliding_claim_ids[1])


### PR DESCRIPTION
Updates the default `tcp_port` setting (used for hosting blobs) to be the same as the default `udp_port` (used for the dht). Both now default to 4444.