### PR TITLE
Add Prometheus metrics for DHT internals

### DIFF
--- a/lbry/dht/protocol/protocol.py
+++ b/lbry/dht/protocol/protocol.py
@@ -276,6 +276,14 @@ class KademliaProtocol(DatagramProtocol):
         "request_success", "Number of successful requests", namespace="dht_node",
         labelnames=("method",),
     )
+    request_flight_metric = Gauge(
+        "request_flight", "Number of ongoing requests", namespace="dht_node",
+        labelnames=("method",),
+    )
+    request_error_metric = Counter(
+        "request_error", "Number of errors returned from request to other peers", namespace="dht_node",
+        labelnames=("method",),
+    )
     HISTOGRAM_BUCKETS = (
         .005, .01, .025, .05, .075, .1, .25, .5, .75, 1.0, 2.5, 3.0, 3.5, 4.0, 4.50, 5.0, 5.50, 6.0, float('inf')
     )
@@ -606,6 +614,7 @@ class KademliaProtocol(DatagramProtocol):
         response_fut = self.sent_messages[request.rpc_id][1]
         try:
             self.request_sent_metric.labels(method=request.method).inc()
+            self.request_flight_metric.labels(method=request.method).inc()
             start = time.perf_counter()
             response = await asyncio.wait_for(response_fut, self.rpc_timeout)
             self.response_time_metric.labels(method=request.method).observe(time.perf_counter() - start)
@@ -617,10 +626,13 @@ class KademliaProtocol(DatagramProtocol):
                 response_fut.cancel()
             raise
         except (asyncio.TimeoutError, RemoteException):
+            self.request_error_metric.labels(method=request.method).inc()
             self.peer_manager.report_failure(peer.address, peer.udp_port)
             if self.peer_manager.peer_is_good(peer) is False:
                 self.remove_peer(peer)
             raise
+        finally:
+            self.request_flight_metric.labels(method=request.method).dec()
 
     def send_response(self, peer: 'KademliaPeer', response: ResponseDatagram):
         self._send(peer, response)

--- a/lbry/dht/protocol/routing_table.py
+++ b/lbry/dht/protocol/routing_table.py
@@ -22,8 +22,8 @@ class KBucket:
         "peers_in_routing_table", "Number of peers on routing table", namespace="dht_node",
         labelnames=("scope",)
     )
-    peer_with_x_byte_colliding_metric = Counter(
-        "peer_x_byte_colliding", "Number of peers with at least X bytes colliding with this node id",
+    peer_with_x_bit_colliding_metric = Counter(
+        "peer_x_bit_colliding", "Number of peers with at least X bits colliding with this node id",
         namespace="dht_node", labelnames=("amount",)
     )
 
@@ -70,9 +70,9 @@ class KBucket:
         if len(self.peers) < constants.K:
             self.peers.append(peer)
             self.peer_in_routing_table_metric.labels("global").inc()
-            if self._node_id[0] == peer.node_id[0]:
-                amount = 2 if self._node_id[1] == peer.node_id[1] else 1
-                self.peer_with_x_byte_colliding_metric.labels(amount=amount).inc()
+            if peer.node_id[0] == self._node_id[0]:
+                bits_colliding = 8 - (peer.node_id[1] ^ self._node_id[1]).bit_length()
+                self.peer_with_x_bit_colliding_metric.labels(amount=(bits_colliding + 8)).inc()
             return True
         else:
             return False

--- a/lbry/dht/protocol/routing_table.py
+++ b/lbry/dht/protocol/routing_table.py
@@ -18,7 +18,7 @@ class KBucket:
     """
     Kademlia K-bucket implementation.
     """
-    peers_in_routing_table_metric = Gauge(
+    peer_in_routing_table_metric = Gauge(
         "peers_in_routing_table", "Number of peers on routing table", namespace="dht_node",
         labelnames=("scope",)
     )
@@ -65,7 +65,7 @@ class KBucket:
                     return True
         if len(self.peers) < constants.K:
             self.peers.append(peer)
-            self.peers_in_routing_table_metric.labels("global").inc()
+            self.peer_in_routing_table_metric.labels("global").inc()
             return True
         else:
             return False
@@ -132,7 +132,7 @@ class KBucket:
 
     def remove_peer(self, peer: 'KademliaPeer') -> None:
         self.peers.remove(peer)
-        self.peers_in_routing_table_metric.labels("global").dec()
+        self.peer_in_routing_table_metric.labels("global").dec()
 
     def key_in_range(self, key: bytes) -> bool:
         """ Tests whether the specified key (i.e. node ID) is in the range
@@ -171,7 +171,7 @@ class TreeRoutingTable:
     ping RPC-based k-bucket eviction algorithm described in section 2.2 of
     that paper.
     """
-    buckets_in_routing_table_metric = Gauge(
+    bucket_in_routing_table_metric = Gauge(
         "buckets_in_routing_table", "Number of buckets on routing table", namespace="dht_node",
         labelnames=("scope",)
     )
@@ -292,7 +292,7 @@ class TreeRoutingTable:
         # ...and remove them from the old bucket
         for contact in new_bucket.peers:
             old_bucket.remove_peer(contact)
-        self.buckets_in_routing_table_metric.labels("global").set(len(self.buckets))
+        self.bucket_in_routing_table_metric.labels("global").set(len(self.buckets))
 
     def join_buckets(self):
         if len(self.buckets) == 1:
@@ -316,7 +316,7 @@ class TreeRoutingTable:
         elif can_go_higher:
             self.buckets[bucket_index_to_pop + 1].range_min = bucket.range_min
         self.buckets.remove(bucket)
-        self.buckets_in_routing_table_metric.labels("global").set(len(self.buckets))
+        self.bucket_in_routing_table_metric.labels("global").set(len(self.buckets))
         return self.join_buckets()
 
     def contact_in_routing_table(self, address_tuple: typing.Tuple[str, int]) -> bool:

--- a/lbry/dht/protocol/routing_table.py
+++ b/lbry/dht/protocol/routing_table.py
@@ -4,6 +4,8 @@ import logging
 import typing
 import itertools
 
+from prometheus_client import Gauge
+
 from lbry.dht import constants
 from lbry.dht.protocol.distance import Distance
 if typing.TYPE_CHECKING:
@@ -13,8 +15,13 @@ log = logging.getLogger(__name__)
 
 
 class KBucket:
-    """ Description - later
     """
+    Kademlia K-bucket implementation.
+    """
+    peers_in_routing_table_metric = Gauge(
+        "peers_in_routing_table", "Number of peers on routing table", namespace="dht_node",
+        labelnames=("scope",)
+    )
 
     def __init__(self, peer_manager: 'PeerManager', range_min: int, range_max: int, node_id: bytes):
         """
@@ -58,6 +65,7 @@ class KBucket:
                     return True
         if len(self.peers) < constants.K:
             self.peers.append(peer)
+            self.peers_in_routing_table_metric.labels("global").inc()
             return True
         else:
             return False
@@ -124,6 +132,7 @@ class KBucket:
 
     def remove_peer(self, peer: 'KademliaPeer') -> None:
         self.peers.remove(peer)
+        self.peers_in_routing_table_metric.labels("global").dec()
 
     def key_in_range(self, key: bytes) -> bool:
         """ Tests whether the specified key (i.e. node ID) is in the range
@@ -162,6 +171,10 @@ class TreeRoutingTable:
     ping RPC-based k-bucket eviction algorithm described in section 2.2 of
     that paper.
     """
+    buckets_in_routing_table_metric = Gauge(
+        "buckets_in_routing_table", "Number of buckets on routing table", namespace="dht_node",
+        labelnames=("scope",)
+    )
 
     def __init__(self, loop: asyncio.AbstractEventLoop, peer_manager: 'PeerManager', parent_node_id: bytes,
                  split_buckets_under_index: int = constants.SPLIT_BUCKETS_UNDER_INDEX):
@@ -279,6 +292,7 @@ class TreeRoutingTable:
         # ...and remove them from the old bucket
         for contact in new_bucket.peers:
             old_bucket.remove_peer(contact)
+        self.buckets_in_routing_table_metric.labels("global").set(len(self.buckets))
 
     def join_buckets(self):
         if len(self.buckets) == 1:
@@ -302,6 +316,7 @@ class TreeRoutingTable:
         elif can_go_higher:
             self.buckets[bucket_index_to_pop + 1].range_min = bucket.range_min
         self.buckets.remove(bucket)
+        self.buckets_in_routing_table_metric.labels("global").set(len(self.buckets))
         return self.join_buckets()
 
     def contact_in_routing_table(self, address_tuple: typing.Tuple[str, int]) -> bool:

--- a/lbry/extras/daemon/daemon.py
+++ b/lbry/extras/daemon/daemon.py
@@ -5149,10 +5149,12 @@ class Daemon(metaclass=JSONRPCServerType):
                     ]
                 },
                 "node_id": (str) the local dht node id
+                "prefix_neighbors_count": (int) the amount of peers sharing the same byte prefix of the local node id
             }
         """
         result = {
-            'buckets': {}
+            'buckets': {},
+            'prefix_neighbors_count': 0
         }
 
         for i, _ in enumerate(self.dht_node.protocol.routing_table.buckets):
@@ -5165,6 +5167,7 @@ class Daemon(metaclass=JSONRPCServerType):
                     "node_id": hexlify(peer.node_id).decode(),
                 }
                 result['buckets'][i].append(host)
+                result['prefix_neighbors_count'] += 1 if peer.node_id[0] == self.dht_node.protocol.node_id[0] else 0
 
         result['node_id'] = hexlify(self.dht_node.protocol.node_id).decode()
         return result

--- a/scripts/dht_node.py
+++ b/scripts/dht_node.py
@@ -56,26 +56,30 @@ class SimpleMetrics:
             writer.writerow({"blob_hash": blob.hex()})
         return web.Response(text=out.getvalue(), content_type='text/csv')
 
-    async def estimate_peers(self, request: web.Request):
-        amount = 2000
+    async def active_estimation(self, request: web.Request):
+        # - "crawls" the network for peers close to our node id (not a full aggressive crawler yet)
+        # given everything is random, the odds of a peer having the same X prefix bits matching ours is roughly 1/(2^X)
+        # we use that to estimate the network size, see issue #3463 for related papers and details
+        amount = 20_000
         peers = await self.dht_node.peer_search(self.dht_node.protocol.node_id, count=amount, max_results=amount)
         close_ids = [peer for peer in peers if peer.node_id[0] == self.dht_node.protocol.node_id[0]]
-        print(self.dht_node.protocol.node_id.hex())
-        print([cid.node_id.hex() for cid in close_ids])
         return web.json_response({"total": len(peers), "close": len(close_ids)})
 
-    async def peers_in_routing_table(self, request: web.Request):
+    async def passive_estimation(self, request: web.Request):
+        # same method as above but instead we use the routing table and assume our implementation was able to add
+        # all the reachable close peers, which should be usable for seed nodes since they are super popular
         total_peers = self.dht_node.protocol.routing_table.get_peers()
         close_ids = [peer for peer in total_peers if peer.node_id[0] == self.dht_node.protocol.node_id[0]]
-        return web.json_response({"total": len(total_peers), "close": len(close_ids), 'estimated_network_size': len(close_ids) * 256})
+        return web.json_response(
+            {"total": len(total_peers), "close": len(close_ids), 'estimated_network_size': len(close_ids) * 256})
 
     async def start(self):
         prom_app = web.Application()
         prom_app.router.add_get('/metrics', self.handle_metrics_get_request)
         prom_app.router.add_get('/peers.csv', self.handle_peers_csv)
         prom_app.router.add_get('/blobs.csv', self.handle_blobs_csv)
-        prom_app.router.add_get('/estimate', self.estimate_peers)
-        prom_app.router.add_get('/count', self.peers_in_routing_table)
+        prom_app.router.add_get('/active_estimation', self.active_estimation)
+        prom_app.router.add_get('/passive_estimation', self.passive_estimation)
         metrics_runner = web.AppRunner(prom_app)
         await metrics_runner.setup()
         prom_site = web.TCPSite(metrics_runner, "0.0.0.0", self.prometheus_port)

--- a/scripts/dht_node.py
+++ b/scripts/dht_node.py
@@ -63,7 +63,7 @@ class SimpleMetrics:
         # given everything is random, the odds of a peer having the same X prefix bits matching ours is roughly 1/(2^X)
         # we use that to estimate the network size, see issue #3463 for related papers and details
         amount = 20_000
-        with self.active_estimation_semaphore:  # this is resource intensive, limit concurrency to 1
+        async with self.active_estimation_semaphore:  # this is resource intensive, limit concurrency to 1
             peers = await self.dht_node.peer_search(self.dht_node.protocol.node_id, count=amount, max_results=amount)
         close_ids = [peer for peer in peers if peer.node_id[0] == self.dht_node.protocol.node_id[0]]
         return web.json_response(

--- a/scripts/dht_node.py
+++ b/scripts/dht_node.py
@@ -6,7 +6,7 @@ import os.path
 from io import StringIO
 from typing import Optional
 from aiohttp import web
-from prometheus_client import generate_latest as prom_generate_latest, Gauge
+from prometheus_client import generate_latest as prom_generate_latest
 
 from lbry.dht.constants import generate_id
 from lbry.dht.node import Node
@@ -16,18 +16,6 @@ from lbry.conf import Config
 
 logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)-4s %(name)s:%(lineno)d: %(message)s")
 log = logging.getLogger(__name__)
-BLOBS_STORED = Gauge(
-    "blobs_stored", "Number of blob info received", namespace="dht_node",
-    labelnames=("method",)
-)
-PEERS = Gauge(
-    "known_peers", "Number of peers on routing table", namespace="dht_node",
-    labelnames=("method",)
-)
-ESTIMATED_SIZE = Gauge(
-    "passively_estimated_network_size", "Estimated network size from routing table", namespace="dht_node",
-    labelnames=("method",)
-)
 
 
 class SimpleMetrics:
@@ -129,11 +117,6 @@ async def main(host: str, port: int, db_file_path: str, bootstrap_node: Optional
     log.info("Peer with id %s started", node_id.hex())
     while True:
         await asyncio.sleep(10)
-        PEERS.labels('main').set(len(node.protocol.routing_table.get_peers()))
-        peers = node.protocol.routing_table.get_peers()
-        close_ids = [peer for peer in peers if peer.node_id[0] == node.protocol.node_id[0]]
-        ESTIMATED_SIZE.labels('main').set(len(close_ids) * 256)
-        BLOBS_STORED.labels('main').set(len(node.protocol.data_store.get_storing_contacts()))
         log.info("Known peers: %d. Storing contact information for %d blobs from %d peers.",
                  len(node.protocol.routing_table.get_peers()), len(node.protocol.data_store),
                  len(node.protocol.data_store.get_storing_contacts()))

--- a/scripts/dht_node.py
+++ b/scripts/dht_node.py
@@ -63,15 +63,20 @@ class SimpleMetrics:
         amount = 20_000
         peers = await self.dht_node.peer_search(self.dht_node.protocol.node_id, count=amount, max_results=amount)
         close_ids = [peer for peer in peers if peer.node_id[0] == self.dht_node.protocol.node_id[0]]
-        return web.json_response({"total": len(peers), "close": len(close_ids)})
+        return web.json_response(
+            {"total_peers_found_during_estimation": len(peers),
+             "peers_with_the_same_byte_prefix": len(close_ids),
+             'estimated_network_size': len(close_ids) * 256})
 
     async def passive_estimation(self, _):
         # same method as above but instead we use the routing table and assume our implementation was able to add
         # all the reachable close peers, which should be usable for seed nodes since they are super popular
-        total_peers = self.dht_node.protocol.routing_table.get_peers()
-        close_ids = [peer for peer in total_peers if peer.node_id[0] == self.dht_node.protocol.node_id[0]]
+        peers = self.dht_node.protocol.routing_table.get_peers()
+        close_ids = [peer for peer in peers if peer.node_id[0] == self.dht_node.protocol.node_id[0]]
         return web.json_response(
-            {"total": len(total_peers), "close": len(close_ids), 'estimated_network_size': len(close_ids) * 256})
+            {"total_peers_found_during_estimation": len(peers),
+             "peers_with_the_same_byte_prefix": len(close_ids),
+             'estimated_network_size': len(close_ids) * 256})
 
     async def start(self):
         prom_app = web.Application()

--- a/scripts/dht_node.py
+++ b/scripts/dht_node.py
@@ -24,6 +24,10 @@ PEERS = Gauge(
     "known_peers", "Number of peers on routing table", namespace="dht_node",
     labelnames=("method",)
 )
+ESTIMATED_SIZE = Gauge(
+    "passively_estimated_network_size", "Estimated network size from routing table", namespace="dht_node",
+    labelnames=("method",)
+)
 
 
 class SimpleMetrics:
@@ -126,6 +130,9 @@ async def main(host: str, port: int, db_file_path: str, bootstrap_node: Optional
     while True:
         await asyncio.sleep(10)
         PEERS.labels('main').set(len(node.protocol.routing_table.get_peers()))
+        peers = node.protocol.routing_table.get_peers()
+        close_ids = [peer for peer in peers if peer.node_id[0] == node.protocol.node_id[0]]
+        ESTIMATED_SIZE.labels('main').set(len(close_ids) * 256)
         BLOBS_STORED.labels('main').set(len(node.protocol.data_store.get_storing_contacts()))
         log.info("Known peers: %d. Storing contact information for %d blobs from %d peers.",
                  len(node.protocol.routing_table.get_peers()), len(node.protocol.data_store),

--- a/scripts/dht_node.py
+++ b/scripts/dht_node.py
@@ -30,7 +30,7 @@ class SimpleMetrics:
         self.prometheus_port = port
         self.dht_node: Node = node
 
-    async def handle_metrics_get_request(self, request: web.Request):
+    async def handle_metrics_get_request(self, _):
         try:
             return web.Response(
                 text=prom_generate_latest().decode(),
@@ -40,7 +40,7 @@ class SimpleMetrics:
             log.exception('could not generate prometheus data')
             raise
 
-    async def handle_peers_csv(self, request: web.Request):
+    async def handle_peers_csv(self, _):
         out = StringIO()
         writer = csv.DictWriter(out, fieldnames=["ip", "port", "dht_id"])
         writer.writeheader()
@@ -48,7 +48,7 @@ class SimpleMetrics:
             writer.writerow({"ip": peer.address, "port": peer.udp_port, "dht_id": peer.node_id.hex()})
         return web.Response(text=out.getvalue(), content_type='text/csv')
 
-    async def handle_blobs_csv(self, request: web.Request):
+    async def handle_blobs_csv(self, _):
         out = StringIO()
         writer = csv.DictWriter(out, fieldnames=["blob_hash"])
         writer.writeheader()
@@ -56,7 +56,7 @@ class SimpleMetrics:
             writer.writerow({"blob_hash": blob.hex()})
         return web.Response(text=out.getvalue(), content_type='text/csv')
 
-    async def active_estimation(self, request: web.Request):
+    async def active_estimation(self, _):
         # - "crawls" the network for peers close to our node id (not a full aggressive crawler yet)
         # given everything is random, the odds of a peer having the same X prefix bits matching ours is roughly 1/(2^X)
         # we use that to estimate the network size, see issue #3463 for related papers and details
@@ -65,7 +65,7 @@ class SimpleMetrics:
         close_ids = [peer for peer in peers if peer.node_id[0] == self.dht_node.protocol.node_id[0]]
         return web.json_response({"total": len(peers), "close": len(close_ids)})
 
-    async def passive_estimation(self, request: web.Request):
+    async def passive_estimation(self, _):
         # same method as above but instead we use the routing table and assume our implementation was able to add
         # all the reachable close peers, which should be usable for seed nodes since they are super popular
         total_peers = self.dht_node.protocol.routing_table.get_peers()


### PR DESCRIPTION
The SDK already supports exporting metrics over Prometheus if the user wishes to do so. This PR adds the following metrics under the `dht_node` namespace:

#### data store
- `stored_blobs_x_bytes_colliding`: Number of blobs with at least X bytes colliding with this node id prefix
    - This is used to measure the ratio of content on network vs on blockchain. Check #3521 and [the dashboard repo](https://github.com/lbryio/dashboard), but it also needs #3511 merged.
- `stored_blobs`: Number of blobs announced by other peers
- `storing_peers`: Number of peers storing blobs announced to this node
#### protocol
- `peer_manager_keys`: Number of keys tracked by PeerManager dicts (sum)
    - If that grows too large, we can get memory leaks
- `request_sent`: Number of requests send from DHT RPC protocol
- `request_success`: Number of successful requests
- `request_error`: Number of errors returned from request to other peers
- `response_time`: Response times of DHT RPC requests
- `received_request`: Number of received DHT RPC requests
#### routing table
- `peers_in_routing_table`: Number of peers on routing table
- `peer_x_bit_colliding`: Number of peers with at least X bits colliding with this node id
    - This is used for estimating network size. Details on #3463, but the raw calculations will live on [the dashboard repo](https://github.com/lbryio/dashboard). This also tells how close we are from the peers we added on the routing table, which can help dissecating a live node health into how well we are able to find and and add neighbors.
- `buckets_in_routing_table`: Number of buckets on routing table
    - Debugging purposes.


### New endpoints:

When starting the seed node script with `--metrics_port=<some_port>`, a web server will expose the following endpoints:

- `/metrics`: Prometheus endpoint with the above metrics.

If desired, routing table peers and announced blobs can be exported in CSV format using `--enable_csv_export`. However, you should use a firewall and avoid exposing that publicly as the announced blobs list can reach multiple thousands items, easily bringing your server down by malicious users.
- `/peers.csv`: All peers from the routing table in CSV format (ip, port, node_id)
- `/blobs.csv`: All blobs announced to the node in CSV format (hex encoded blob hash)
