### PR TITLE
convert hexdata argument to a string before signing in `channel_sign` command

### DIFF
--- a/lbry/extras/daemon/daemon.py
+++ b/lbry/extras/daemon/daemon.py
@@ -2908,14 +2908,13 @@ class Daemon(metaclass=JSONRPCServerType):
                 "signing_ts":   (str) The timestamp used to sign the comment,
             }
         """
-        hexdata = str(hexdata)
         wallet = self.wallet_manager.get_wallet_or_default(wallet_id)
         assert not wallet.is_locked, "Cannot spend funds with locked wallet, unlock first."
         signing_channel = await self.get_channel_or_error(
             wallet, channel_account_id, channel_id, channel_name, for_signing=True
         )
         timestamp = str(int(time.time()))
-        signature = signing_channel.sign_data(unhexlify(hexdata), timestamp)
+        signature = signing_channel.sign_data(unhexlify(str(hexdata)), timestamp)
         return {
             'signature': signature,
             'signing_ts': timestamp

--- a/lbry/extras/daemon/daemon.py
+++ b/lbry/extras/daemon/daemon.py
@@ -2908,6 +2908,7 @@ class Daemon(metaclass=JSONRPCServerType):
                 "signing_ts":   (str) The timestamp used to sign the comment,
             }
         """
+        hexdata = str(hexdata)
         wallet = self.wallet_manager.get_wallet_or_default(wallet_id)
         assert not wallet.is_locked, "Cannot spend funds with locked wallet, unlock first."
         signing_channel = await self.get_channel_or_error(

--- a/tests/integration/claims/test_claim_commands.py
+++ b/tests/integration/claims/test_claim_commands.py
@@ -1233,6 +1233,8 @@ class ChannelCommands(CommandTestCase):
         signature2 = await self.out(self.daemon.jsonrpc_channel_sign(channel_id=channel.claim_id, hexdata=data_to_sign))
         self.assertTrue(verify(channel, unhexlify(data_to_sign), signature1))
         self.assertTrue(verify(channel, unhexlify(data_to_sign), signature2))
+        signature3 = await self.out(self.daemon.jsonrpc_channel_sign(channel_id=channel.claim_id, hexdata=99))
+        self.assertTrue(verify(channel, unhexlify('99'), signature3))
 
     async def test_channel_export_import_before_sending_channel(self):
         # export


### PR DESCRIPTION
Converts `hexdata` to a string before it is signed in `jsonrpc_channel_sign()`.

Fixes #3533