### PR TITLE
Increase DHT peer manager cache size to 16384

### DIFF
--- a/lbry/dht/peer.py
+++ b/lbry/dht/peer.py
@@ -11,7 +11,7 @@ from lbry.dht import constants
 from lbry.dht.serialization.datagram import make_compact_address, make_compact_ip, decode_compact_address
 
 ALLOW_LOCALHOST = False
-CACHE_SIZE = 2048
+CACHE_SIZE = 16384
 log = logging.getLogger(__name__)
 
 


### PR DESCRIPTION
Theoretical impact from raw measurements on `memory_profiler` was 6mb of memory worst case.
Practical impact of a running node with 500 streams was a reduction (probably because 6mb is irrelevant if compared to overall usage pattern).
This is expected to close #3550 but other PR will follow with iterative find fixes that were discovered in the process.