### PR TITLE
DHT: improve iterative find

### DIFF
--- a/lbry/dht/protocol/iterative_find.py
+++ b/lbry/dht/protocol/iterative_find.py
@@ -360,8 +360,8 @@ class IterativeNodeFinder(IterativeFinder):
         if self.are_k_closest_peers_ready:
             self.put_result(self.active.keys(), True)
         elif self.bottom_out_count >= self.bottom_out_limit or self.iteration_count >= self.bottom_out_limit:
-            log.debug("peer search bottomed out.")
-            self.put_result(self.active.keys(), True)
+            log.warning("peer search bottomed out.")
+            self.put_result([], True)
 
 
 class IterativeValueFinder(IterativeFinder):

--- a/lbry/dht/protocol/iterative_find.py
+++ b/lbry/dht/protocol/iterative_find.py
@@ -86,7 +86,7 @@ class IterativeFinder:
 
         self.key = key
         self.bottom_out_limit = bottom_out_limit
-        self.max_results = max_results
+        self.max_results = max(constants.K, max_results)
         self.exclude = exclude or []
 
         self.active: typing.Dict['KademliaPeer', int] = {}  # peer: distance, sorted
@@ -228,6 +228,8 @@ class IterativeFinder:
             if peer in self.contacted:
                 continue
             if added >= constants.ALPHA:
+                break
+            if index > self.max_results:
                 break
             origin_address = (peer.address, peer.udp_port)
             if origin_address in self.exclude:


### PR DESCRIPTION
- uses a dict instead
- bottoming out on peer search gives a warning and returns empty (returning earlier could give bad results for announcements, so imo it is preferable to fail entirely)
- probes a lot less (stops probing if it goes outside of the top `max_result` closest nodes) = less packets, same precision, more concurrency expected

depends: #3559 