### PR TITLE
DHT: stop announcing the head blob

### DIFF
--- a/lbry/extras/daemon/migrator/dbmigrator.py
+++ b/lbry/extras/daemon/migrator/dbmigrator.py
@@ -37,6 +37,8 @@ def migrate_db(conf, start, end):
             from .migrate13to14 import do_migration
         elif current == 14:
             from .migrate14to15 import do_migration
+        elif current == 15:
+            from .migrate15to16 import do_migration
         else:
             raise Exception(f"DB migration of version {current} to {current+1} is not available")
         try:

--- a/lbry/extras/daemon/migrator/migrate15to16.py
+++ b/lbry/extras/daemon/migrator/migrate15to16.py
@@ -1,0 +1,17 @@
+import os
+import sqlite3
+
+
+def do_migration(conf):
+    db_path = os.path.join(conf.data_dir, "lbrynet.sqlite")
+    connection = sqlite3.connect(db_path)
+    cursor = connection.cursor()
+
+    cursor.executescript("""
+        update blob set should_announce=0
+        where should_announce=1 and 
+        blob.blob_hash in (select stream_blob.blob_hash from stream_blob where position=0);
+    """)
+
+    connection.commit()
+    connection.close()

--- a/lbry/extras/daemon/storage.py
+++ b/lbry/extras/daemon/storage.py
@@ -187,8 +187,8 @@ def store_stream(transaction: sqlite3.Connection, sd_blob: 'BlobFile', descripto
     ).fetchall()
     # ensure should_announce is set regardless if insert was ignored
     transaction.execute(
-        "update blob set should_announce=1 where blob_hash in (?, ?)",
-        (sd_blob.blob_hash, descriptor.blobs[0].blob_hash,)
+        "update blob set should_announce=1 where blob_hash in (?)",
+        (sd_blob.blob_hash,)
     ).fetchall()
 
 

--- a/lbry/stream/downloader.py
+++ b/lbry/stream/downloader.py
@@ -98,10 +98,6 @@ class StreamDownloader:
         if not self.descriptor:
             await self.load_descriptor(connection_id)
 
-        # add the head blob to the peer search
-        self.search_queue.put_nowait(self.descriptor.blobs[0].blob_hash)
-        log.info("added head blob to peer search for stream %s", self.sd_hash)
-
         if not await self.blob_manager.storage.stream_exists(self.sd_hash) and save_stream:
             await self.blob_manager.storage.store_stream(
                 self.blob_manager.get_blob(self.sd_hash, length=self.descriptor.length), self.descriptor

--- a/tests/integration/datanetwork/test_file_commands.py
+++ b/tests/integration/datanetwork/test_file_commands.py
@@ -107,18 +107,12 @@ class FileCommands(CommandTestCase):
         self.assertEqual(await self.daemon.storage.get_blobs_to_announce(), [])
         await self.stream_create('foo', '0.01')
         stream = (await self.daemon.jsonrpc_file_list())["items"][0]
-        self.assertSetEqual(
-            set(await self.daemon.storage.get_blobs_to_announce()),
-            {stream.sd_hash, stream.descriptor.blobs[0].blob_hash}
-        )
+        self.assertSetEqual(set(await self.daemon.storage.get_blobs_to_announce()), {stream.sd_hash})
         self.assertTrue(await self.daemon.jsonrpc_file_delete(delete_all=True))
         # announces on download
         self.assertEqual(await self.daemon.storage.get_blobs_to_announce(), [])
         stream = await self.daemon.jsonrpc_get('foo')
-        self.assertSetEqual(
-            set(await self.daemon.storage.get_blobs_to_announce()),
-            {stream.sd_hash, stream.descriptor.blobs[0].blob_hash}
-        )
+        self.assertSetEqual(set(await self.daemon.storage.get_blobs_to_announce()), {stream.sd_hash})
 
     async def _purge_file(self, claim_name, full_path):
         self.assertTrue(

--- a/tests/unit/stream/test_reflector.py
+++ b/tests/unit/stream/test_reflector.py
@@ -97,7 +97,7 @@ class TestReflector(AsyncioTestCase):
     async def test_announces(self):
         to_announce = await self.storage.get_blobs_to_announce()
         self.assertIn(self.stream.sd_hash, to_announce, "sd blob not set to announce")
-        self.assertIn(self.stream.descriptor.blobs[0].blob_hash, to_announce, "head blob not set to announce")
+        self.assertNotIn(self.stream.descriptor.blobs[0].blob_hash, to_announce, "head blob set to announce")
 
     async def test_result_from_disconnect_mid_sd_transfer(self):
         stop = asyncio.Event()


### PR DESCRIPTION
backwards-incompatible: includes a migration, increasing the database version. This usually means you can't downgrade without a database backup.

This should make 1 announcement per stream instead of 2.
- stop announcing the head blob
- stop searching for it
- migration script to set all head blobs to should_announce=false

part of #3527 but probably doesn't close it (faster hash announcer and tracker to go)