### PR TITLE
Fixes bugs on disk space management and stream recovery

### DIFF
--- a/lbry/blob/blob_file.py
+++ b/lbry/blob/blob_file.py
@@ -201,7 +201,7 @@ class AbstractBlob:
         writer = blob.get_blob_writer()
         writer.write(blob_bytes)
         await blob.verified.wait()
-        return BlobInfo(blob_num, length, binascii.hexlify(iv).decode(), blob_hash, added_on, is_mine)
+        return BlobInfo(blob_num, length, binascii.hexlify(iv).decode(), added_on, blob_hash, is_mine)
 
     def save_verified_blob(self, verified_bytes: bytes):
         if self.verified.is_set():

--- a/lbry/blob/blob_info.py
+++ b/lbry/blob/blob_info.py
@@ -1,4 +1,3 @@
-import time
 import typing
 
 
@@ -13,13 +12,13 @@ class BlobInfo:
     ]
 
     def __init__(
-            self, blob_num: int, length: int, iv: str,
-             blob_hash: typing.Optional[str] = None, added_on=0, is_mine=False):
+            self, blob_num: int, length: int, iv: str, added_on,
+             blob_hash: typing.Optional[str] = None, is_mine=False):
         self.blob_hash = blob_hash
         self.blob_num = blob_num
         self.length = length
         self.iv = iv
-        self.added_on = added_on or time.time()
+        self.added_on = added_on
         self.is_mine = is_mine
 
     def as_dict(self) -> typing.Dict:

--- a/lbry/blob/blob_info.py
+++ b/lbry/blob/blob_info.py
@@ -1,3 +1,4 @@
+import time
 import typing
 
 
@@ -18,7 +19,7 @@ class BlobInfo:
         self.blob_num = blob_num
         self.length = length
         self.iv = iv
-        self.added_on = added_on
+        self.added_on = added_on or time.time()
         self.is_mine = is_mine
 
     def as_dict(self) -> typing.Dict:

--- a/lbry/extras/daemon/migrator/migrate8to9.py
+++ b/lbry/extras/daemon/migrator/migrate8to9.py
@@ -20,7 +20,7 @@ def do_migration(conf):
                            "left outer join blob b ON b.blob_hash=s.blob_hash order by s.position").fetchall()
     blobs_by_stream = {}
     for stream_hash, position, iv, blob_hash, blob_length in blobs:
-        blobs_by_stream.setdefault(stream_hash, []).append(BlobInfo(position, blob_length or 0, iv, blob_hash))
+        blobs_by_stream.setdefault(stream_hash, []).append(BlobInfo(position, blob_length or 0, iv, 0, blob_hash))
 
     for stream_name, stream_key, suggested_filename, sd_hash, stream_hash in streams:
         sd = StreamDescriptor(None, blob_dir, stream_name, stream_key, suggested_filename,

--- a/lbry/extras/daemon/storage.py
+++ b/lbry/extras/daemon/storage.py
@@ -449,7 +449,7 @@ class SQLiteStorage(SQLiteMixin):
             return await self.db.execute_fetchall(
                 "select blob.blob_hash, blob.blob_length, blob.added_on "
                 "from blob left join stream_blob using (blob_hash) "
-                "where stream_blob.stream_hash is null and blob.is_mine=?"
+                "where stream_blob.stream_hash is null and blob.is_mine=? "
                 "order by blob.blob_length desc, blob.added_on asc",
                 (is_mine,)
             )

--- a/lbry/extras/daemon/storage.py
+++ b/lbry/extras/daemon/storage.py
@@ -449,7 +449,8 @@ class SQLiteStorage(SQLiteMixin):
             return await self.db.execute_fetchall(
                 "select blob.blob_hash, blob.blob_length, blob.added_on "
                 "from blob left join stream_blob using (blob_hash) "
-                "where stream_blob.stream_hash is null and blob.is_mine=? order by blob.added_on asc",
+                "where stream_blob.stream_hash is null and blob.is_mine=?"
+                "order by blob.blob_length desc, blob.added_on asc",
                 (is_mine,)
             )
 
@@ -479,7 +480,7 @@ class SQLiteStorage(SQLiteMixin):
                coalesce(sum(case when
                    is_mine=1
                then blob_length else 0 end), 0) as private_storage
-        from blob left join stream_blob using (blob_hash)
+        from blob left join stream_blob using (blob_hash) where blob_hash not in (select sd_hash from stream)
         """)
         return {
             'network_storage': network_size,

--- a/lbry/stream/descriptor.py
+++ b/lbry/stream/descriptor.py
@@ -194,12 +194,13 @@ class StreamDescriptor:
             raise InvalidStreamDescriptorError("Stream terminator blob should not have a hash")
         if any(i != blob_info['blob_num'] for i, blob_info in enumerate(decoded['blobs'])):
             raise InvalidStreamDescriptorError("Stream contains out of order or skipped blobs")
+        added_on = time.time()
         descriptor = cls(
             loop, blob_dir,
             binascii.unhexlify(decoded['stream_name']).decode(),
             decoded['key'],
             binascii.unhexlify(decoded['suggested_file_name']).decode(),
-            [BlobInfo(info['blob_num'], info['length'], info['iv'], info.get('blob_hash'))
+            [BlobInfo(info['blob_num'], info['length'], info['iv'], added_on, info.get('blob_hash'))
              for info in decoded['blobs']],
             decoded['stream_hash'],
             blob.blob_hash
@@ -266,7 +267,7 @@ class StreamDescriptor:
             blobs.append(blob_info)
         blobs.append(
             # add the stream terminator
-            BlobInfo(len(blobs), 0, binascii.hexlify(next(iv_generator)).decode(), None, added_on, True)
+            BlobInfo(len(blobs), 0, binascii.hexlify(next(iv_generator)).decode(), added_on, None, True)
         )
         file_name = os.path.basename(file_path)
         suggested_file_name = sanitize_file_name(file_name)

--- a/tests/integration/datanetwork/test_file_commands.py
+++ b/tests/integration/datanetwork/test_file_commands.py
@@ -573,6 +573,12 @@ class DiskSpaceManagement(CommandTestCase):
         self.assertTrue(blobs2.issubset(blobs))
         self.assertFalse(blobs3.issubset(blobs))
         self.assertTrue(blobs4.issubset(blobs))
+        # check that added_on gets set on downloads (was a bug)
+        self.assertLess(0, await self.daemon.storage.run_and_return_one_or_none("select min(added_on) from blob"))
+        await self.daemon.jsonrpc_file_delete(delete_all=True)
+        await self.daemon.jsonrpc_get("foo4", save_file=False)
+        self.assertLess(0, await self.daemon.storage.run_and_return_one_or_none("select min(added_on) from blob"))
+
 
 
 class TestBackgroundDownloaderComponent(CommandTestCase):

--- a/tests/integration/datanetwork/test_file_commands.py
+++ b/tests/integration/datanetwork/test_file_commands.py
@@ -580,7 +580,6 @@ class DiskSpaceManagement(CommandTestCase):
         self.assertLess(0, await self.daemon.storage.run_and_return_one_or_none("select min(added_on) from blob"))
 
 
-
 class TestBackgroundDownloaderComponent(CommandTestCase):
     async def get_blobs_from_sd_blob(self, sd_blob):
         descriptor = await StreamDescriptor.from_stream_descriptor_blob(

--- a/tests/unit/database/test_SQLiteStorage.py
+++ b/tests/unit/database/test_SQLiteStorage.py
@@ -84,7 +84,7 @@ class StorageTest(AsyncioTestCase):
         await self.storage.add_blobs((blob_hash, length, 0, 0), finished=True)
 
     async def store_fake_stream(self, stream_hash, blobs=None, file_name="fake_file", key="DEADBEEF"):
-        blobs = blobs or [BlobInfo(1, 100, "DEADBEEF", random_lbry_hash())]
+        blobs = blobs or [BlobInfo(1, 100, "DEADBEEF", 0, random_lbry_hash())]
         descriptor = StreamDescriptor(
             asyncio.get_event_loop(), self.blob_dir, file_name, key, file_name, blobs, stream_hash
         )
@@ -95,7 +95,7 @@ class StorageTest(AsyncioTestCase):
     async def make_and_store_fake_stream(self, blob_count=2, stream_hash=None):
         stream_hash = stream_hash or random_lbry_hash()
         blobs = [
-            BlobInfo(i + 1, 100, "DEADBEEF", random_lbry_hash())
+            BlobInfo(i + 1, 100, "DEADBEEF", 0, random_lbry_hash())
             for i in range(blob_count)
         ]
         await self.store_fake_stream(stream_hash, blobs)


### PR DESCRIPTION
- fixes bug where `blob_clean` (disk space management) would clean sd blobs from a SQL bad query
- fix bug where `added_on` is 0 for all blobs except sd blob
- change disk space management order to delete sd blobs last on both cases (seeding and normal space)
- fix bug where stream recovery would set sd blob as 'pending' and recover again every startup while also losing status for all other blobs in a stream
- on startup, if a blob is present but pending on db, check length and fix status