### PR TITLE
Tighten up IterativeFinder async close behavior (DHT iterator continues after consumer breaks out of it)

### DIFF
--- a/lbry/dht/protocol/iterative_find.py
+++ b/lbry/dht/protocol/iterative_find.py
@@ -276,8 +276,8 @@ class IterativeFinder(AsyncGenerator):
     async def __anext__(self) -> typing.List['KademliaPeer']:
         return await super().__anext__()
 
-    async def asend(self, val):
-        return await self.generator.asend(val)
+    async def asend(self, value):
+        return await self.generator.asend(value)
 
     async def athrow(self, typ, val=None, tb=None):
         return await self.generator.athrow(typ, val, tb)

--- a/lbry/dht/protocol/iterative_find.py
+++ b/lbry/dht/protocol/iterative_find.py
@@ -175,7 +175,8 @@ class IterativeFinder(AsyncGenerator):
             self._reset_closest(peer)
             return
         except TransportNotConnected:
-            return self._aclose()
+            await self._aclose(reason="not connected")
+            return
         except RemoteException:
             self._reset_closest(peer)
             return

--- a/lbry/dht/protocol/iterative_find.py
+++ b/lbry/dht/protocol/iterative_find.py
@@ -287,8 +287,6 @@ class IterativeFinder(AsyncGenerator):
         running_tasks = list(chain(self.tasks, self.running_probes.values()))
         for task in running_tasks:
             task.cancel()
-        if len(running_tasks):
-            await asyncio.wait(running_tasks, loop=self.loop)
         log.debug("%s[%x] [%s] async close because %s: %i active nodes %i contacted %i produced %i queued",
                   type(self).__name__, id(self), self.key.hex()[:8],
                   reason, len(self.active), len(self.contacted),

--- a/lbry/utils.py
+++ b/lbry/utils.py
@@ -130,6 +130,12 @@ def get_sd_hash(stream_info):
 def json_dumps_pretty(obj, **kwargs):
     return json.dumps(obj, sort_keys=True, indent=2, separators=(',', ': '), **kwargs)
 
+@contextlib.asynccontextmanager
+async def aclosing(thing):
+    try:
+        yield thing
+    finally:
+        await thing.aclose()
 
 def async_timed_cache(duration: int):
     def wrapper(func):

--- a/lbry/utils.py
+++ b/lbry/utils.py
@@ -132,7 +132,7 @@ def json_dumps_pretty(obj, **kwargs):
 
 try:
     # the standard contextlib.aclosing() is available in 3.10+
-    from contextlib import aclosing
+    from contextlib import aclosing  # pylint: disable=unused-import
 except ImportError:
     @contextlib.asynccontextmanager
     async def aclosing(thing):

--- a/lbry/utils.py
+++ b/lbry/utils.py
@@ -130,12 +130,16 @@ def get_sd_hash(stream_info):
 def json_dumps_pretty(obj, **kwargs):
     return json.dumps(obj, sort_keys=True, indent=2, separators=(',', ': '), **kwargs)
 
-@contextlib.asynccontextmanager
-async def aclosing(thing):
-    try:
-        yield thing
-    finally:
-        await thing.aclose()
+try:
+    # the standard contextlib.aclosing() is available in 3.10+
+    from contextlib import aclosing
+except ImportError:
+    @contextlib.asynccontextmanager
+    async def aclosing(thing):
+        try:
+            yield thing
+        finally:
+            await thing.aclose()
 
 def async_timed_cache(duration: int):
     def wrapper(func):


### PR DESCRIPTION
See: https://github.com/lbryio/lbry-sdk/issues/3504

Script:
[scratch.py.txt](https://github.com/lbryio/lbry-sdk/files/8476728/scratch.py.txt)

Script output:
[scratch_1.txt](https://github.com/lbryio/lbry-sdk/files/8476723/scratch_1.txt)

Initially there is a lot of background activity from IterativeNodeFinder during what I presume is startup.
In steady state there is little activity after each "PAUSE---". Usually just stuff related to cancellation, if anything.

Eventually, I hope the "async with aclosing(...)" feature can be used:
https://docs.python.org/3.10/library/contextlib.html?highlight=aclosing#contextlib.aclosing
