### PR TITLE
add --no_password_change flag to sync apply

### DIFF
--- a/lbry/extras/daemon/daemon.py
+++ b/lbry/extras/daemon/daemon.py
@@ -1960,23 +1960,23 @@ class Daemon(metaclass=JSONRPCServerType):
         return hexlify(wallet.hash).decode()
 
     @requires("wallet")
-    async def jsonrpc_sync_apply(self, password, data=None, wallet_id=None, blocking=False):
+    async def jsonrpc_sync_apply(self, password, data=None, wallet_id=None, no_password_change=False, blocking=False):
         """
         Apply incoming synchronization data, if provided, and return a sync hash and update wallet data.
 
         Wallet must be unlocked to perform this operation.
 
-        If "encrypt-on-disk" preference is True and supplied password is different from local password,
-        or there is no local password (because local wallet was not encrypted), then the supplied password
-        will be used for local encryption (overwriting previous local encryption password).
+        If "encrypt-on-disk" preference is True, then in all cases the wallet will be updated to use the
+        supplied password for local encryption unless --only_export is passed.
 
         Usage:
-            sync_apply <password> [--data=<data>] [--wallet_id=<wallet_id>] [--blocking]
+            sync_apply <password> [--data=<data>] [--wallet_id=<wallet_id>] [--no_password_change] [--blocking]
 
         Options:
             --password=<password>         : (str) password to decrypt incoming and encrypt outgoing data
             --data=<data>                 : (str) incoming sync data, if any
             --wallet_id=<wallet_id>       : (str) wallet being sync'ed
+            --no_password_change          : (bool) do not update existing wallet encryption password
             --blocking                    : (bool) wait until any new accounts have sync'ed
 
         Returns:
@@ -1998,7 +1998,11 @@ class Daemon(metaclass=JSONRPCServerType):
                     for new_account in added_accounts:
                         asyncio.create_task(self.ledger.subscribe_account(new_account))
             wallet_changed = True
-        if wallet.preferences.get(ENCRYPT_ON_DISK, False) and password != wallet.encryption_password:
+        if (
+            wallet.preferences.get(ENCRYPT_ON_DISK, False) and
+            password != wallet.encryption_password and
+            not no_password_change
+        ):
             wallet.encryption_password = password
             wallet_changed = True
         if wallet_changed:

--- a/tests/integration/blockchain/test_wallet_commands.py
+++ b/tests/integration/blockchain/test_wallet_commands.py
@@ -387,6 +387,11 @@ class WalletEncryptionAndSynchronization(CommandTestCase):
         # need to use new password2 in sync_apply
         with self.assertRaises(InvalidPasswordError):
             await daemon.jsonrpc_sync_apply('password', data=data['data'], blocking=True)
+        # first test --no_password_change
+        await daemon.jsonrpc_sync_apply('password2', data=data['data'], blocking=True, no_password_change=True)
+        # sync_apply should leave original password
+        self.assertEqual(wallet.encryption_password, 'password')
+        # now test with password change to password2
         await daemon.jsonrpc_sync_apply('password2', data=data['data'], blocking=True)
         # sync_apply with new password2 also sets it as new local password
         self.assertEqual(wallet.encryption_password, 'password2')


### PR DESCRIPTION
Using sync apply to export wallet shouldn't necessarily change my local password. 