### PR TITLE
disable Hotbit and UPBit exchange rate feeds

### DIFF
--- a/lbry/extras/daemon/exchange_rate_manager.py
+++ b/lbry/extras/daemon/exchange_rate_manager.py
@@ -196,9 +196,9 @@ FEEDS: Iterable[Type[MarketFeed]] = (
     BittrexUSDFeed,
     CoinExBTCFeed,
     CoinExUSDFeed,
-    HotbitBTCFeed,
-    HotbitUSDFeed,
-    UPbitBTCFeed,
+#    HotbitBTCFeed,
+#    HotbitUSDFeed,
+#    UPbitBTCFeed,
 )
 
 

--- a/tests/integration/other/test_exchange_rate_manager.py
+++ b/tests/integration/other/test_exchange_rate_manager.py
@@ -1,8 +1,9 @@
 import asyncio
-import logging
 from decimal import Decimal
 from lbry.testcase import AsyncioTestCase
-from lbry.extras.daemon.exchange_rate_manager import ExchangeRate, ExchangeRateManager, FEEDS, MarketFeed
+from lbry.extras.daemon.exchange_rate_manager import (
+    ExchangeRate, ExchangeRateManager, FEEDS, MarketFeed
+)
 
 
 class TestExchangeRateManager(AsyncioTestCase):


### PR DESCRIPTION
UPBit delisted LBC in 2021
Hotbit shutdown