### PR TITLE
Correct the terminal height we wait for in generate()

### DIFF
--- a/lbry/testcase.py
+++ b/lbry/testcase.py
@@ -327,9 +327,9 @@ class IntegrationTestCase(AsyncioTestCase):
     async def generate(self, blocks):
         """ Ask lbrycrd to generate some blocks and wait until ledger has them. """
         prepare = self.ledger.on_header.where(self.blockchain.is_expected_block)
-        height = self.blockchain.block_expected + blocks
         self.conductor.spv_node.server.synchronized.clear()
         await self.blockchain.generate(blocks)
+        height = self.blockchain.block_expected
         await prepare  # no guarantee that it didn't happen already, so start waiting from before calling generate
         while True:
             await self.conductor.spv_node.server.synchronized.wait()

--- a/lbry/testcase.py
+++ b/lbry/testcase.py
@@ -308,8 +308,11 @@ class IntegrationTestCase(AsyncioTestCase):
             while True:
                 await self.conductor.spv_node.server.synchronized.wait()
                 self.conductor.spv_node.server.synchronized.clear()
-                if self.conductor.spv_node.server.db.db_height >= height:
-                    break
+                if (self.conductor.spv_node.server.db.db_height < height):
+                    continue
+                if (self.conductor.spv_node.server._es_height < height):
+                    continue
+                break
 
     def on_address_update(self, address):
         return self.ledger.on_transaction.where(
@@ -331,8 +334,11 @@ class IntegrationTestCase(AsyncioTestCase):
         while True:
             await self.conductor.spv_node.server.synchronized.wait()
             self.conductor.spv_node.server.synchronized.clear()
-            if self.conductor.spv_node.server.db.db_height >= height:
-                break
+            if (self.conductor.spv_node.server.db.db_height < height):
+                continue
+            if (self.conductor.spv_node.server._es_height < height):
+                continue
+            break
 
 
 class FakeExchangeRateManager(ExchangeRateManager):

--- a/lbry/testcase.py
+++ b/lbry/testcase.py
@@ -308,9 +308,9 @@ class IntegrationTestCase(AsyncioTestCase):
             while True:
                 await self.conductor.spv_node.server.synchronized.wait()
                 self.conductor.spv_node.server.synchronized.clear()
-                if (self.conductor.spv_node.server.db.db_height < height):
+                if self.conductor.spv_node.server.db.db_height < height:
                     continue
-                if (self.conductor.spv_node.server._es_height < height):
+                if self.conductor.spv_node.server._es_height < height:
                     continue
                 break
 
@@ -334,9 +334,9 @@ class IntegrationTestCase(AsyncioTestCase):
         while True:
             await self.conductor.spv_node.server.synchronized.wait()
             self.conductor.spv_node.server.synchronized.clear()
-            if (self.conductor.spv_node.server.db.db_height < height):
+            if self.conductor.spv_node.server.db.db_height < height:
                 continue
-            if (self.conductor.spv_node.server._es_height < height):
+            if self.conductor.spv_node.server._es_height < height:
                 continue
             break
 

--- a/lbry/testcase.py
+++ b/lbry/testcase.py
@@ -327,7 +327,7 @@ class IntegrationTestCase(AsyncioTestCase):
     async def generate(self, blocks):
         """ Ask lbrycrd to generate some blocks and wait until ledger has them. """
         prepare = self.ledger.on_header.where(self.blockchain.is_expected_block)
-        height = self.blockchain.block_expected
+        height = self.blockchain.block_expected + blocks
         self.conductor.spv_node.server.synchronized.clear()
         await self.blockchain.generate(blocks)
         await prepare  # no guarantee that it didn't happen already, so start waiting from before calling generate

--- a/tests/integration/takeovers/test_resolve_command.py
+++ b/tests/integration/takeovers/test_resolve_command.py
@@ -1555,18 +1555,10 @@ class ResolveAfterReorg(BaseResolveTestCase):
         blocks = self.ledger.headers.height - start
         self.blockchain.block_expected = start - 1
 
-
-        prepare = self.ledger.on_header.where(self.blockchain.is_expected_block)
-        self.conductor.spv_node.server.synchronized.clear()
-
         # go back to start
         await self.blockchain.invalidate_block((await self.ledger.headers.hash(start)).decode())
         # go to previous + 1
-        await self.blockchain.generate(blocks + 2)
-
-        await prepare  # no guarantee that it didn't happen already, so start waiting from before calling generate
-        await self.conductor.spv_node.server.synchronized.wait()
-        # await asyncio.wait_for(self.on_header(self.blockchain.block_expected), 30.0)
+        await self.generate(blocks + 2)
 
     async def assertBlockHash(self, height):
         reader_db = self.conductor.spv_node.server.db

--- a/tests/integration/takeovers/test_resolve_command.py
+++ b/tests/integration/takeovers/test_resolve_command.py
@@ -22,14 +22,14 @@ class ClaimStateValue(NamedTuple):
 class BaseResolveTestCase(CommandTestCase):
 
     def assertMatchESClaim(self, claim_from_es, claim_from_db):
-        self.assertEqual(claim_from_es['claim_hash'][::-1].hex(), claim_from_db.claim_hash.hex())
-        self.assertEqual(claim_from_es['claim_id'], claim_from_db.claim_hash.hex())
+        self.assertEqual(claim_from_es['claim_hash'][::-1].hex(), claim_from_db.claim_hash.hex(), f'ES: {str(claim_from_es)} DB: {str(claim_from_db)}')
+        self.assertEqual(claim_from_es['claim_id'], claim_from_db.claim_hash.hex(), f'ES: {str(claim_from_es)} DB: {str(claim_from_db)}')
         self.assertEqual(claim_from_es['activation_height'], claim_from_db.activation_height, f"es height: {claim_from_es['activation_height']}, rocksdb height: {claim_from_db.activation_height}")
-        self.assertEqual(claim_from_es['last_take_over_height'], claim_from_db.last_takeover_height)
-        self.assertEqual(claim_from_es['tx_id'], claim_from_db.tx_hash[::-1].hex())
-        self.assertEqual(claim_from_es['tx_nout'], claim_from_db.position)
-        self.assertEqual(claim_from_es['amount'], claim_from_db.amount)
-        self.assertEqual(claim_from_es['effective_amount'], claim_from_db.effective_amount)
+        self.assertEqual(claim_from_es['last_take_over_height'], claim_from_db.last_takeover_height, f'ES: {str(claim_from_es)} DB: {str(claim_from_db)}')
+        self.assertEqual(claim_from_es['tx_id'], claim_from_db.tx_hash[::-1].hex(), f'ES: {str(claim_from_es)} DB: {str(claim_from_db)}')
+        self.assertEqual(claim_from_es['tx_nout'], claim_from_db.position, f'ES: {str(claim_from_es)} DB: {str(claim_from_db)}')
+        self.assertEqual(claim_from_es['amount'], claim_from_db.amount, f'ES: {str(claim_from_es)} DB: {str(claim_from_db)}')
+        self.assertEqual(claim_from_es['effective_amount'], claim_from_db.effective_amount, f'ES: {str(claim_from_es)} DB: {str(claim_from_db)}')
 
     def assertMatchDBClaim(self, expected, claim):
         self.assertEqual(expected['claimid'], claim.claim_hash.hex())
@@ -1499,10 +1499,10 @@ class ResolveClaimTakeovers(BaseResolveTestCase):
         await self.assertNameState(272, name, second_claim_id, last_takeover_height=272, non_winning_claims=[])
 
     async def test_trending(self):
-        async def get_trending_score(claim_id):
+        async def get_claim(claim_id):
             return (await self.conductor.spv_node.server.session_manager.search_index.search(
                 claim_id=claim_id
-            ))[0][0]['trending_score']
+            ))[0][0]
 
         claim_id1 = (await self.stream_create('derp', '1.0'))['outputs'][0]['claim_id']
         COIN = int(1E8)
@@ -1514,19 +1514,22 @@ class ResolveClaimTakeovers(BaseResolveTestCase):
         await self.generate(1)
         self.assertEqual(self.conductor.spv_node.writer.height, 208)
 
-        self.assertEqual(1.7090807854206793, await get_trending_score(claim_id1))
+        claim1 = await get_claim(claim_id1)
+        self.assertEqual(1.7090807854206793, claim1['trending_score'], str(claim1))
         self.conductor.spv_node.writer.db.prefix_db.trending_notification.stage_put(
             (209, bytes.fromhex(claim_id1)), (10 * COIN, 100 * COIN)
         )
         await self.generate(1)
         self.assertEqual(self.conductor.spv_node.writer.height, 209)
-        self.assertEqual(2.2437974397778886, await get_trending_score(claim_id1))
+        claim1 = await get_claim(claim_id1)
+        self.assertEqual(2.2437974397778886, claim1['trending_score'], str(claim1))
         self.conductor.spv_node.writer.db.prefix_db.trending_notification.stage_put(
             (309, bytes.fromhex(claim_id1)), (100 * COIN, 1000000 * COIN)
         )
         await self.generate(100)
         self.assertEqual(self.conductor.spv_node.writer.height, 309)
-        self.assertEqual(5.157053472135866, await get_trending_score(claim_id1))
+        claim1 = await get_claim(claim_id1)
+        self.assertEqual(5.157053472135866, claim1['trending_score'], str(claim1))
 
         self.conductor.spv_node.writer.db.prefix_db.trending_notification.stage_put(
             (409, bytes.fromhex(claim_id1)), (1000000 * COIN, 1 * COIN)
@@ -1534,12 +1537,14 @@ class ResolveClaimTakeovers(BaseResolveTestCase):
 
         await self.generate(99)
         self.assertEqual(self.conductor.spv_node.writer.height, 408)
-        self.assertEqual(5.157053472135866, await get_trending_score(claim_id1))
+        claim1 = await get_claim(claim_id1)
+        self.assertEqual(5.157053472135866, claim1['trending_score'], str(claim1))
 
         await self.generate(1)
         self.assertEqual(self.conductor.spv_node.writer.height, 409)
 
-        self.assertEqual(-3.4256156592205627, await get_trending_score(claim_id1))
+        claim1 = await get_claim(claim_id1)
+        self.assertEqual(-3.4256156592205627, claim1['trending_score'], str(claim1))
         search_results = (await self.conductor.spv_node.server.session_manager.search_index.search(claim_name="derp"))[0]
         self.assertEqual(1, len(search_results))
         self.assertListEqual([claim_id1], [c['claim_id'] for c in search_results])


### PR DESCRIPTION
Fixes #3653 

Though generate() was written in a way that appears to wait for herald `db_height` to reach the expected value, it is not waiting for the correct terminal height (i.e. current + blocks_to_generate). Instead, generate() could return early anytime `_es_height` and `db_height` match.

I believe this was causing several integration tests to fail. Herald and Elastic Search were not in fact at the expected height when claims were fetched.