### PR TITLE
Wait for hub to update with all 100 new blocks before proceeding with initial_headers_sync().

### DIFF
--- a/tests/integration/blockchain/test_network.py
+++ b/tests/integration/blockchain/test_network.py
@@ -102,7 +102,7 @@ class ReconnectTests(IntegrationTestCase):
         await self.ledger.stop()
         initial_height = self.ledger.local_height_including_downloaded_height
         await self.blockchain.generate(100)
-        while self.conductor.spv_node.server.session_manager.notified_height < initial_height + 99:  # off by 1
+        while self.conductor.spv_node.server.session_manager.notified_height < initial_height + 100:
             await asyncio.sleep(0.1)
         self.assertEqual(initial_height, self.ledger.local_height_including_downloaded_height)
         await self.ledger.headers.open()


### PR DESCRIPTION
Fixes #3655

Looking to submit this after #3654... (or I could incorporate it into that.)