### PR TITLE
usage payment service more resilient, will continue running until funds available to pay usage fee

### DIFF
--- a/lbry/wallet/ledger.py
+++ b/lbry/wallet/ledger.py
@@ -722,6 +722,15 @@ class Ledger(metaclass=LedgerRegistry):
                 return account.address_managers[details['chain']]
         return None
 
+    async def broadcast_or_release(self, tx, blocking=False):
+        try:
+            await self.broadcast(tx)
+        except:
+            await self.release_tx(tx)
+            raise
+        if blocking:
+            await self.wait(tx, timeout=None)
+
     def broadcast(self, tx):
         # broadcast can't be a retriable call yet
         return self.network.broadcast(hexlify(tx.raw).decode())

--- a/lbry/wallet/manager.py
+++ b/lbry/wallet/manager.py
@@ -317,10 +317,4 @@ class WalletManager:
         )
 
     async def broadcast_or_release(self, tx, blocking=False):
-        try:
-            await self.ledger.broadcast(tx)
-        except:
-            await self.ledger.release_tx(tx)
-            raise
-        if blocking:
-            await self.ledger.wait(tx, timeout=None)
+        await self.ledger.broadcast_or_release(tx, blocking=blocking)

--- a/lbry/wallet/usage_payment.py
+++ b/lbry/wallet/usage_payment.py
@@ -83,7 +83,7 @@ class WalletServerPayer:
             )
 
             log.info("pay loop: before transaction broadcast")
-            await self.ledger.broadcast(tx)
+            await self.ledger.broadcast_or_release(tx, blocking=True)
             if self.analytics_manager:
                 await self.analytics_manager.send_credits_sent()
             log.info("pay loop: after transaction broadcast")

--- a/lbry/wallet/usage_payment.py
+++ b/lbry/wallet/usage_payment.py
@@ -101,11 +101,13 @@ class WalletServerPayer:
     def _done_callback(self, f):
         if f.cancelled():
             reason = "Cancelled"
+        elif f.exception():
+            reason = f'Exception: {f.exception()}'
         elif not self.running:
             reason = "Stopped"
         else:
-            reason = f'Exception: {f.exception()}'
-        log.info("Stopping wallet server payments. %s", reason)
+            reason = ""
+        log.warning("Stopping wallet server payments. %s", reason)
 
     async def stop(self):
         if self.running:

--- a/lbry/wallet/usage_payment.py
+++ b/lbry/wallet/usage_payment.py
@@ -1,9 +1,8 @@
 import asyncio
 import logging
-import sys
-import traceback
 
 from lbry.error import (
+    InsufficientFundsError,
     ServerPaymentFeeAboveMaxAllowedError,
     ServerPaymentInvalidAddressError,
     ServerPaymentWalletLockedError
@@ -26,67 +25,66 @@ class WalletServerPayer:
         self.max_fee = max_fee
         self._on_payment_controller = StreamController()
         self.on_payment = self._on_payment_controller.stream
-        self.on_payment.listen(None, on_error=lambda e: logging.warning(e.args[0]))
+        self.on_payment.listen(None, on_error=lambda e: log.warning(e.args[0]))
 
     async def pay(self):
         while self.running:
             try:
                 await self._pay()
-            except BaseException:
-                if self.running:
-                    traceback.print_exception(*sys.exc_info())
-                    log.warning("Caught exception: %s", sys.exc_info()[0].__name__)
-                else:
-                    log.warning("Caught exception: %s", sys.exc_info()[0].__name__)
+            except (asyncio.TimeoutError, ConnectionError):
+                if not self.running:
+                    break
+                delay = max(self.payment_period / 24, 10)
+                log.warning("Payement failed. Will retry after %g seconds.", delay)
+                asyncio.sleep(delay)
+            except Exception:
+                log.exception("Unexpected exception. Payment task exiting early.")
                 raise
-                #if not self.running:
-                #    raise
 
     async def _pay(self):
         while self.running:
-            log.info("pay loop: before sleep")
             await asyncio.sleep(self.payment_period)
-            log.info("pay loop: before get_server_features")
-            features = await self.ledger.network.retriable_call(self.ledger.network.get_server_features)
-            log.info("pay loop: received features: %s", str(features))
+            features = await self.ledger.network.get_server_features()
+            log.debug("pay loop: received server features: %s", str(features))
             address = features['payment_address']
             amount = str(features['daily_fee'])
             if not address or not amount:
-                log.warning("pay loop: no address or no amount")
+                log.debug("pay loop: no address or no amount")
                 continue
 
             if not self.ledger.is_pubkey_address(address):
-                log.warning("pay loop: address not pubkey")
+                log.info("pay loop: address not pubkey")
                 self._on_payment_controller.add_error(ServerPaymentInvalidAddressError(address))
                 continue
 
             if self.wallet.is_locked:
-                log.warning("pay loop: wallet is locked")
+                log.info("pay loop: wallet is locked")
                 self._on_payment_controller.add_error(ServerPaymentWalletLockedError())
                 continue
 
             amount = lbc_to_dewies(features['daily_fee'])  # check that this is in lbc and not dewies
             limit = lbc_to_dewies(self.max_fee)
             if amount > limit:
-                log.warning("pay loop: amount (%d) > limit (%d)", amount, limit)
+                log.info("pay loop: amount (%d) > limit (%d)", amount, limit)
                 self._on_payment_controller.add_error(
                     ServerPaymentFeeAboveMaxAllowedError(features['daily_fee'], self.max_fee)
                 )
                 continue
 
-            log.info("pay loop: before transaction create")
-            tx = await Transaction.create(
-                [],
-                [Output.pay_pubkey_hash(amount, self.ledger.address_to_hash160(address))],
-                self.wallet.get_accounts_or_all(None),
-                self.wallet.get_account_or_default(None)
-            )
+            try:
+                tx = await Transaction.create(
+                    [],
+                    [Output.pay_pubkey_hash(amount, self.ledger.address_to_hash160(address))],
+                    self.wallet.get_accounts_or_all(None),
+                    self.wallet.get_account_or_default(None)
+                )
+            except InsufficientFundsError as e:
+                self._on_payment_controller.add_error(e)
+                continue
 
-            log.info("pay loop: before transaction broadcast")
             await self.ledger.broadcast_or_release(tx, blocking=True)
             if self.analytics_manager:
                 await self.analytics_manager.send_credits_sent()
-            log.info("pay loop: after transaction broadcast")
             self._on_payment_controller.add(tx)
 
     async def start(self, ledger=None, wallet=None):

--- a/lbry/wallet/usage_payment.py
+++ b/lbry/wallet/usage_payment.py
@@ -107,7 +107,7 @@ class WalletServerPayer:
             reason = "Stopped"
         else:
             reason = ""
-        log.warning("Stopping wallet server payments. %s", reason)
+        log.info("Stopping wallet server payments. %s", reason)
 
     async def stop(self):
         if self.running:

--- a/tests/integration/blockchain/test_wallet_server_sessions.py
+++ b/tests/integration/blockchain/test_wallet_server_sessions.py
@@ -3,7 +3,7 @@ import asyncio
 from hub.herald import HUB_PROTOCOL_VERSION
 from hub.herald.session import LBRYElectrumX
 
-from lbry.error import ServerPaymentFeeAboveMaxAllowedError
+from lbry.error import InsufficientFundsError, ServerPaymentFeeAboveMaxAllowedError
 from lbry.wallet.network import ClientSession
 from lbry.wallet.rpc import RPCError
 from lbry.testcase import IntegrationTestCase, CommandTestCase
@@ -48,7 +48,7 @@ class TestUsagePayment(CommandTestCase):
     async def test_single_server_payment(self):
         wallet_pay_service = self.daemon.component_manager.get_component('wallet_server_payments')
         self.assertFalse(wallet_pay_service.running)
-        wallet_pay_service.payment_period = 0.1
+        wallet_pay_service.payment_period = 0.5
         # only starts with a positive max key fee
         wallet_pay_service.max_fee = "0.0"
         await wallet_pay_service.start(ledger=self.ledger, wallet=self.wallet)
@@ -74,19 +74,24 @@ class TestUsagePayment(CommandTestCase):
         self.assertEqual(features["daily_fee"], "1.1")
         with self.assertRaises(ServerPaymentFeeAboveMaxAllowedError):
             await asyncio.wait_for(wallet_pay_service.on_payment.first, timeout=30)
-        node.server.env.daily_fee = "0.1"
+        node.server.env.daily_fee = "1.0"
         node.server.env.payment_address = address
         LBRYElectrumX.set_server_features(node.server.env)
         # self.daemon.jsonrpc_settings_set('lbryum_servers', [f"{node.hostname}:{node.port}"])
         await self.daemon.jsonrpc_wallet_reconnect()
         features = await self.ledger.network.get_server_features()
         self.assertEqual(features["payment_address"], address)
-        self.assertEqual(features["daily_fee"], "0.1")
+        self.assertEqual(features["daily_fee"], "1.0")
         tx = await asyncio.wait_for(wallet_pay_service.on_payment.first, timeout=30)
         self.assertIsNotNone(await self.blockchain.get_raw_transaction(tx.id))  # verify its broadcasted
-        self.assertEqual(tx.outputs[0].amount, 10000000)
+        self.assertEqual(tx.outputs[0].amount, 100000000)
         self.assertEqual(tx.outputs[0].get_address(self.ledger), address)
 
+        # continue paying until account is out of funds
+        with self.assertRaises(InsufficientFundsError):
+            for i in range(10):
+                await asyncio.wait_for(wallet_pay_service.on_payment.first, timeout=30)
+        self.assertTrue(wallet_pay_service.running)
 
 class TestESSync(CommandTestCase):
     async def test_es_sync_utility(self):


### PR DESCRIPTION
Fixes #3663

The WalletServerPayer was receiving `asyncio.CancelledError` from `retriable_call()` because `jsonrpc_wallet_reconnect()` creates a situation where the connection is totally gone.

I reworked how it handles exceptions so it tolerates ConnectionError, InsufficientFundsError without exiting prematurely.

Plan to revert https://github.com/lbryio/lbry-sdk/pull/3668/commits/44228961e688c2513a2ac9d2ba127c9009b54577 which is for push button testing.