### PR TITLE
Miscellaneous fixes for intermittent test failures 2

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -160,7 +160,7 @@ jobs:
           path: ${{ steps.pip-cache.outputs.dir }}
           key: ${{ runner.os }}-pip-${{ hashFiles('setup.py') }}
           restore-keys: ${{ runner.os }}-pip-
-      - run: pip install pyinstaller==4.4
+      - run: pip install pyinstaller==4.6
       - run: pip install -e .
       - if: startsWith(github.ref, 'refs/tags/v')
         run: python docker/set_build.py

--- a/lbry/wallet/orchstr8/node.py
+++ b/lbry/wallet/orchstr8/node.py
@@ -214,6 +214,7 @@ class SPVNode:
         self.port = 50001 + node_number  # avoid conflict with default daemon
         self.udp_port = self.port
         self.elastic_notifier_port = 19080 + node_number
+        self.elastic_services = f'localhost:9200/localhost:{self.elastic_notifier_port}'
         self.session_timeout = 600
         self.stopped = True
         self.index_name = uuid4().hex
@@ -235,7 +236,7 @@ class SPVNode:
                 'host': self.hostname,
                 'tcp_port': self.port,
                 'udp_port': self.udp_port,
-                'elastic_notifier_port': self.elastic_notifier_port,
+                'elastic_services': self.elastic_services,
                 'session_timeout': self.session_timeout,
                 'max_query_workers': 0,
                 'es_index_prefix': self.index_name,

--- a/lbry/wallet/wallet.py
+++ b/lbry/wallet/wallet.py
@@ -182,6 +182,8 @@ class Wallet:
                 raise InvalidPasswordError()
             if "unknown compression method" in e.args[0].lower():
                 raise InvalidPasswordError()
+            if "invalid window size" in e.args[0].lower():
+                raise InvalidPasswordError()
             raise
         return json.loads(decompressed)
 

--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ setup(
             'jsonschema==4.4.0',
         ],
         'hub': [
-            'hub@git+https://github.com/lbryio/hub.git@dcd4d7a7a8de3ab41d9fb859b910c3b962eaa2fe'
+            'hub@git+https://github.com/lbryio/hub.git@929448d64bcbe6c5e476757ec78456beaa85e56a'
         ]
     },
     classifiers=[

--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ setup(
             'jsonschema==4.4.0',
         ],
         'hub': [
-            'hub@git+https://github.com/lbryio/hub.git@9b178222296aecc7699cf82141c7a48fe866f22a'
+            'hub@git+https://github.com/lbryio/hub.git@dcd4d7a7a8de3ab41d9fb859b910c3b962eaa2fe'
         ]
     },
     classifiers=[

--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ setup(
             'jsonschema==4.4.0',
         ],
         'hub': [
-            'hub@git+https://github.com/lbryio/hub.git@024aceda53fe6d1ab8d519b73584437c25de6975'
+            'hub@git+https://github.com/lbryio/hub.git@9b178222296aecc7699cf82141c7a48fe866f22a'
         ]
     },
     classifiers=[

--- a/tests/integration/takeovers/test_resolve_command.py
+++ b/tests/integration/takeovers/test_resolve_command.py
@@ -1508,27 +1508,27 @@ class ResolveClaimTakeovers(BaseResolveTestCase):
         COIN = int(1E8)
 
         self.assertEqual(self.conductor.spv_node.writer.height, 207)
-        self.conductor.spv_node.writer.db.prefix_db.trending_notification.stage_put(
+        self.conductor.spv_node.writer.db.prefix_db.trending_notification.stash_put(
             (208, bytes.fromhex(claim_id1)), (0, 10 * COIN)
         )
         await self.generate(1)
         self.assertEqual(self.conductor.spv_node.writer.height, 208)
 
         self.assertEqual(1.7090807854206793, await get_trending_score(claim_id1))
-        self.conductor.spv_node.writer.db.prefix_db.trending_notification.stage_put(
+        self.conductor.spv_node.writer.db.prefix_db.trending_notification.stash_put(
             (209, bytes.fromhex(claim_id1)), (10 * COIN, 100 * COIN)
         )
         await self.generate(1)
         self.assertEqual(self.conductor.spv_node.writer.height, 209)
         self.assertEqual(2.2437974397778886, await get_trending_score(claim_id1))
-        self.conductor.spv_node.writer.db.prefix_db.trending_notification.stage_put(
+        self.conductor.spv_node.writer.db.prefix_db.trending_notification.stash_put(
             (309, bytes.fromhex(claim_id1)), (100 * COIN, 1000000 * COIN)
         )
         await self.generate(100)
         self.assertEqual(self.conductor.spv_node.writer.height, 309)
         self.assertEqual(5.157053472135866, await get_trending_score(claim_id1))
 
-        self.conductor.spv_node.writer.db.prefix_db.trending_notification.stage_put(
+        self.conductor.spv_node.writer.db.prefix_db.trending_notification.stash_put(
             (409, bytes.fromhex(claim_id1)), (1000000 * COIN, 1 * COIN)
         )
 

--- a/tests/unit/wallet/test_database.py
+++ b/tests/unit/wallet/test_database.py
@@ -470,7 +470,7 @@ class TestUpgrade(AsyncioTestCase):
 
 
 class TestSQLiteRace(AsyncioTestCase):
-    max_misuse_attempts = 80000
+    max_misuse_attempts = 120000
 
     def setup_db(self):
         self.db = sqlite3.connect(":memory:", isolation_level=None)


### PR DESCRIPTION
This completes pretty much all the work I planned to do on lbry-sdk test reliability. It should unblock more python3.9 work.

Fixes #3665
Fixes #3671 

Bumping hub gets us the benefit of these fixes:
https://github.com/lbryio/hub/issues/98
https://github.com/lbryio/hub/issues/101
https://github.com/lbryio/hub/issues/104

I also revisited #3658 because I encountered a new zlib.error "invalid window size".

I've started seeing failures like this when running tests. Something changed in the environment I think.
https://github.com/moodyjon/lbry-sdk/actions/runs/3447835647/jobs/5754426649
Successful run from 2mo ago with python 3.7.14 (failure was with 3.7.15):
https://github.com/moodyjon/lbry-sdk/actions/runs/3108575245/jobs/5038289310
Upgrade to pyinstaller==4.6 was suggested here:
https://github.com/pyinstaller/pyinstaller/issues/6325
