### PR TITLE
Handle workflow deprecations

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -37,18 +37,18 @@ jobs:
           python-version: '3.7'
       - name: set pip cache dir (linux/mac)
         if: runner.os != 'Windows'
-        id: pip-cache
-        run: echo "PIP_CACHE_DIR=$(pip cache dir)" >> $GITHUB_OUTPUT
+        id: pip-cache-nix
+        run: echo "PIP_CACHE_DIR=$(pip cache dir)" >> $GITHUB_ENV
       - name: set pip cache dir (windows)
         if: runner.os == 'Windows'
-        id: pip-cache
-        run: echo "PIP_CACHE_DIR=$(pip cache dir)" >> $env:GITHUB_OUTPUT
+        id: pip-cache-win
+        run: echo "PIP_CACHE_DIR=$(pip cache dir)" >> $env:GITHUB_ENV
       - name: debug pip cache
-        run: echo "PIP_CACHE_DIR=${{ steps.pip-cache.outputs.PIP_CACHE_DIR }}"
+        run: echo "PIP_CACHE_DIR=${{ env.PIP_CACHE_DIR }}"
       - name: extract pip cache
         uses: actions/cache@v3
         with:
-          path: ${{ steps.pip-cache.outputs.PIP_CACHE_DIR }}
+          path: ${{ env.PIP_CACHE_DIR }}
           key: ${{ runner.os }}-pip-${{ hashFiles('setup.py') }}
           restore-keys: ${{ runner.os }}-pip-
       - id: os-name
@@ -160,18 +160,18 @@ jobs:
           string: ${{ runner.os }}
       - name: set pip cache dir (linux/mac)
         if: runner.os != 'Windows'
-        id: pip-cache
-        run: echo "PIP_CACHE_DIR=$(pip cache dir)" >> $GITHUB_OUTPUT
+        id: pip-cache-nix
+        run: echo "PIP_CACHE_DIR=$(pip cache dir)" >> $GITHUB_ENV
       - name: set pip cache dir (windows)
         if: runner.os == 'Windows'
-        id: pip-cache
-        run: echo "PIP_CACHE_DIR=$(pip cache dir)" >> $env:GITHUB_OUTPUT
+        id: pip-cache-win
+        run: echo "PIP_CACHE_DIR=$(pip cache dir)" >> $env:GITHUB_ENV
       - name: debug pip cache
-        run: echo "PIP_CACHE_DIR=${{ steps.pip-cache.outputs.PIP_CACHE_DIR }}"
+        run: echo "PIP_CACHE_DIR=${{ env.PIP_CACHE_DIR }}"
       - name: extract pip cache
         uses: actions/cache@v3
         with:
-          path: ${{ steps.pip-cache.outputs.PIP_CACHE_DIR }}
+          path: ${{ env.PIP_CACHE_DIR }}
           key: ${{ runner.os }}-pip-${{ hashFiles('setup.py') }}
           restore-keys: ${{ runner.os }}-pip-
       - run: pip install pyinstaller==4.6

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -189,7 +189,7 @@ jobs:
           pip install pywin32==301
           pyinstaller --additional-hooks-dir=scripts/. --icon=icons/lbry256.ico --onefile --name lbrynet lbry/extras/cli.py
           dist/lbrynet.exe --version
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: lbrynet-${{ steps.os-name.outputs.lowercase }}
           path: dist/

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -35,14 +35,11 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: '3.7'
-      - name: set pip cache dir (linux/mac)
-        if: (!startsWith(runner.os, 'windows'))
-        id: pip-cache-nix
-        run: echo "PIP_CACHE_DIR=$(pip cache dir)" >> $GITHUB_ENV
-      - name: set pip cache dir (windows)
-        if: startsWith(runner.os, 'windows')
-        id: pip-cache-win
-        run: echo "PIP_CACHE_DIR=$(pip cache dir)" >> $env:GITHUB_ENV
+      - name: set pip cache dir
+        - if: (!startsWith(runner.os, 'windows'))
+          run: echo "PIP_CACHE_DIR=$(pip cache dir)" >> $GITHUB_ENV
+        - if: startsWith(runner.os, 'windows')
+          run: echo "PIP_CACHE_DIR=$(pip cache dir)" >> $env:GITHUB_ENV
       - name: debug pip cache
         run: echo "PIP_CACHE_DIR=${{ env.PIP_CACHE_DIR }}"
       - name: extract pip cache
@@ -158,14 +155,11 @@ jobs:
         uses: ASzc/change-string-case-action@v5
         with:
           string: ${{ runner.os }}
-      - name: set pip cache dir (linux/mac)
-        if: (!startsWith(runner.os, 'windows'))
-        id: pip-cache-nix
-        run: echo "PIP_CACHE_DIR=$(pip cache dir)" >> $GITHUB_ENV
-      - name: set pip cache dir (windows)
-        if: startsWith(runner.os, 'windows')
-        id: pip-cache-win
-        run: echo "PIP_CACHE_DIR=$(pip cache dir)" >> $env:GITHUB_ENV
+      - name: set pip cache dir
+        - if: (!startsWith(runner.os, 'windows'))
+          run: echo "PIP_CACHE_DIR=$(pip cache dir)" >> $GITHUB_ENV
+        - if: startsWith(runner.os, 'windows')
+          run: echo "PIP_CACHE_DIR=$(pip cache dir)" >> $env:GITHUB_ENV
       - name: debug pip cache
         run: echo "PIP_CACHE_DIR=${{ env.PIP_CACHE_DIR }}"
       - name: extract pip cache

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -35,13 +35,20 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: '3.7'
-      - name: set pip cache dir
+      - name: set pip cache dir (linux/mac)
+        if: runner.os != 'Windows'
         id: pip-cache
-        run: echo "::set-output name=dir::$(pip cache dir)"
+        run: echo "PIP_CACHE_DIR=$(pip cache dir)" >> $GITHUB_OUTPUT
+      - name: set pip cache dir (windows)
+        if: runner.os == 'Windows'
+        id: pip-cache
+        run: echo "PIP_CACHE_DIR=$(pip cache dir)" >> $env:GITHUB_OUTPUT
+      - name: debug pip cache
+        run: echo "PIP_CACHE_DIR=${{ steps.pip-cache.outputs.PIP_CACHE_DIR }}"
       - name: extract pip cache
         uses: actions/cache@v3
         with:
-          path: ${{ steps.pip-cache.outputs.dir }}
+          path: ${{ steps.pip-cache.outputs.PIP_CACHE_DIR }}
           key: ${{ runner.os }}-pip-${{ hashFiles('setup.py') }}
           restore-keys: ${{ runner.os }}-pip-
       - id: os-name
@@ -151,13 +158,20 @@ jobs:
         uses: ASzc/change-string-case-action@v1
         with:
           string: ${{ runner.os }}
-      - name: set pip cache dir
+      - name: set pip cache dir (linux/mac)
+        if: runner.os != 'Windows'
         id: pip-cache
-        run: echo "::set-output name=dir::$(pip cache dir)"
+        run: echo "PIP_CACHE_DIR=$(pip cache dir)" >> $GITHUB_OUTPUT
+      - name: set pip cache dir (windows)
+        if: runner.os == 'Windows'
+        id: pip-cache
+        run: echo "PIP_CACHE_DIR=$(pip cache dir)" >> $env:GITHUB_OUTPUT
+      - name: debug pip cache
+        run: echo "PIP_CACHE_DIR=${{ steps.pip-cache.outputs.PIP_CACHE_DIR }}"
       - name: extract pip cache
         uses: actions/cache@v3
         with:
-          path: ${{ steps.pip-cache.outputs.dir }}
+          path: ${{ steps.pip-cache.outputs.PIP_CACHE_DIR }}
           key: ${{ runner.os }}-pip-${{ hashFiles('setup.py') }}
           restore-keys: ${{ runner.os }}-pip-
       - run: pip install pyinstaller==4.6

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -35,11 +35,10 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: '3.7'
-      - name: set pip cache dir
-        - if: (!startsWith(runner.os, 'windows'))
-          run: echo "PIP_CACHE_DIR=$(pip cache dir)" >> $GITHUB_ENV
-        - if: startsWith(runner.os, 'windows')
-          run: echo "PIP_CACHE_DIR=$(pip cache dir)" >> $env:GITHUB_ENV
+      - if: (!startsWith(runner.os, 'windows'))
+        run: echo "PIP_CACHE_DIR=$(pip cache dir)" >> $GITHUB_ENV
+      - if: startsWith(runner.os, 'windows')
+        run: echo "PIP_CACHE_DIR=$(pip cache dir)" >> $env:GITHUB_ENV
       - name: debug pip cache
         run: echo "PIP_CACHE_DIR=${{ env.PIP_CACHE_DIR }}"
       - name: extract pip cache
@@ -155,11 +154,10 @@ jobs:
         uses: ASzc/change-string-case-action@v5
         with:
           string: ${{ runner.os }}
-      - name: set pip cache dir
-        - if: (!startsWith(runner.os, 'windows'))
-          run: echo "PIP_CACHE_DIR=$(pip cache dir)" >> $GITHUB_ENV
-        - if: startsWith(runner.os, 'windows')
-          run: echo "PIP_CACHE_DIR=$(pip cache dir)" >> $env:GITHUB_ENV
+      - if: (!startsWith(runner.os, 'windows'))
+        run: echo "PIP_CACHE_DIR=$(pip cache dir)" >> $GITHUB_ENV
+      - if: startsWith(runner.os, 'windows')
+        run: echo "PIP_CACHE_DIR=$(pip cache dir)" >> $env:GITHUB_ENV
       - name: debug pip cache
         run: echo "PIP_CACHE_DIR=${{ env.PIP_CACHE_DIR }}"
       - name: extract pip cache

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -35,10 +35,9 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: '3.7'
-      - if: (!startsWith(runner.os, 'windows'))
+      - name: set pip cache dir
+        shell: bash
         run: echo "PIP_CACHE_DIR=$(pip cache dir)" >> $GITHUB_ENV
-      - if: startsWith(runner.os, 'windows')
-        run: echo "PIP_CACHE_DIR=$(pip cache dir)" >> $env:GITHUB_ENV
       - name: extract pip cache
         uses: actions/cache@v3
         with:
@@ -152,10 +151,9 @@ jobs:
         uses: ASzc/change-string-case-action@v5
         with:
           string: ${{ runner.os }}
-      - if: (!startsWith(runner.os, 'windows'))
+      - name: set pip cache dir
+        shell: bash
         run: echo "PIP_CACHE_DIR=$(pip cache dir)" >> $GITHUB_ENV
-      - if: startsWith(runner.os, 'windows')
-        run: echo "PIP_CACHE_DIR=$(pip cache dir)" >> $env:GITHUB_ENV
       - name: extract pip cache
         uses: actions/cache@v3
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,12 +7,12 @@ jobs:
     name: lint
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v1
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
         with:
           python-version: '3.7'
       - name: extract pip cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/.cache/pip
           key: ${{ runner.os }}-pip-${{ hashFiles('setup.py') }}
@@ -31,15 +31,15 @@ jobs:
           - windows-latest
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v1
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
         with:
           python-version: '3.7'
       - name: set pip cache dir
         id: pip-cache
         run: echo "::set-output name=dir::$(pip cache dir)"
       - name: extract pip cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ${{ steps.pip-cache.outputs.dir }}
           key: ${{ runner.os }}-pip-${{ hashFiles('setup.py') }}
@@ -93,8 +93,8 @@ jobs:
         uses: elastic/elastic-github-actions/elasticsearch@master
         with:
           stack-version: 7.12.1
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v1
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
         with:
           python-version: '3.7'
       - if: matrix.test == 'other'
@@ -102,7 +102,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends ffmpeg
       - name: extract pip cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ./.tox
           key: tox-integration-${{ matrix.test }}-${{ hashFiles('setup.py') }}
@@ -143,8 +143,8 @@ jobs:
           - windows-latest
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v1
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
         with:
           python-version: '3.7'
       - id: os-name
@@ -155,7 +155,7 @@ jobs:
         id: pip-cache
         run: echo "::set-output name=dir::$(pip cache dir)"
       - name: extract pip cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ${{ steps.pip-cache.outputs.dir }}
           key: ${{ runner.os }}-pip-${{ hashFiles('setup.py') }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -39,8 +39,6 @@ jobs:
         run: echo "PIP_CACHE_DIR=$(pip cache dir)" >> $GITHUB_ENV
       - if: startsWith(runner.os, 'windows')
         run: echo "PIP_CACHE_DIR=$(pip cache dir)" >> $env:GITHUB_ENV
-      - name: debug pip cache
-        run: echo "PIP_CACHE_DIR=${{ env.PIP_CACHE_DIR }}"
       - name: extract pip cache
         uses: actions/cache@v3
         with:
@@ -158,8 +156,6 @@ jobs:
         run: echo "PIP_CACHE_DIR=$(pip cache dir)" >> $GITHUB_ENV
       - if: startsWith(runner.os, 'windows')
         run: echo "PIP_CACHE_DIR=$(pip cache dir)" >> $env:GITHUB_ENV
-      - name: debug pip cache
-        run: echo "PIP_CACHE_DIR=${{ env.PIP_CACHE_DIR }}"
       - name: extract pip cache
         uses: actions/cache@v3
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -36,11 +36,11 @@ jobs:
         with:
           python-version: '3.7'
       - name: set pip cache dir (linux/mac)
-        if: runner.os != 'Windows'
+        if: (!startsWith(runner.os, 'windows'))
         id: pip-cache-nix
         run: echo "PIP_CACHE_DIR=$(pip cache dir)" >> $GITHUB_ENV
       - name: set pip cache dir (windows)
-        if: runner.os == 'Windows'
+        if: startsWith(runner.os, 'windows')
         id: pip-cache-win
         run: echo "PIP_CACHE_DIR=$(pip cache dir)" >> $env:GITHUB_ENV
       - name: debug pip cache
@@ -52,7 +52,7 @@ jobs:
           key: ${{ runner.os }}-pip-${{ hashFiles('setup.py') }}
           restore-keys: ${{ runner.os }}-pip-
       - id: os-name
-        uses: ASzc/change-string-case-action@v1
+        uses: ASzc/change-string-case-action@v5
         with:
           string: ${{ runner.os }}
       - run: python -m pip install --user --upgrade pip wheel
@@ -155,15 +155,15 @@ jobs:
         with:
           python-version: '3.7'
       - id: os-name
-        uses: ASzc/change-string-case-action@v1
+        uses: ASzc/change-string-case-action@v5
         with:
           string: ${{ runner.os }}
       - name: set pip cache dir (linux/mac)
-        if: runner.os != 'Windows'
+        if: (!startsWith(runner.os, 'windows'))
         id: pip-cache-nix
         run: echo "PIP_CACHE_DIR=$(pip cache dir)" >> $GITHUB_ENV
       - name: set pip cache dir (windows)
-        if: runner.os == 'Windows'
+        if: startsWith(runner.os, 'windows')
         id: pip-cache-win
         run: echo "PIP_CACHE_DIR=$(pip cache dir)" >> $env:GITHUB_ENV
       - name: debug pip cache


### PR DESCRIPTION
Fixes #3721

I discovered that the:
echo "var=value" >> $GITHUB_OUTPUT
needs to be (on windows only):
echo "var=value" >> $env:GITHUB_OUTPUT

That's the main reason I switched to using $GITHUB_ENV instead of $GITHUB_OUTPUT. At least reading from the variable looks the same on windows & linux/Mac.