### PR TITLE
WIP: Support multiple blob dirs and (optional) hierarchical structure within each blob dir

### DIFF
--- a/lbry/blob/blob_file.py
+++ b/lbry/blob/blob_file.py
@@ -19,6 +19,9 @@ from lbry.blob import MAX_BLOB_SIZE, BLOBHASH_LENGTH
 from lbry.blob.blob_info import BlobInfo
 from lbry.blob.writer import HashBlobWriter
 
+if typing.TYPE_CHECKING:
+    from lbry.blob.blob_manager import BlobManager
+
 log = logging.getLogger(__name__)
 
 
@@ -79,13 +82,20 @@ class AbstractBlob:
     def __init__(
         self, loop: asyncio.AbstractEventLoop, blob_hash: str, length: typing.Optional[int] = None,
         blob_completed_callback: typing.Optional[typing.Callable[['AbstractBlob'], asyncio.Task]] = None,
-        blob_directory: typing.Optional[str] = None, added_on: typing.Optional[int] = None, is_mine: bool = False,
+        blob_manager: typing.Optional['BlobManager'] = None,
+        added_on: typing.Optional[int] = None, is_mine: bool = False,
     ):
+        if not is_valid_blobhash(blob_hash):
+            raise InvalidBlobHashError(blob_hash)
+        from lbry.blob.blob_manager import BlobManager # pylint: disable=import-outside-toplevel
+        if not isinstance(blob_manager, BlobManager):
+            raise TypeError(f"{type(blob_manager)} not instance of BlobManager")
+
         self.loop = loop
         self.blob_hash = blob_hash
         self.length = length
         self.blob_completed_callback = blob_completed_callback
-        self.blob_directory = blob_directory
+        self.blob_directory, _ = blob_manager._blob_dir(blob_hash)
         self.writers: typing.Dict[typing.Tuple[typing.Optional[str], typing.Optional[int]], HashBlobWriter] = {}
         self.verified: asyncio.Event = asyncio.Event()
         self.writing: asyncio.Event = asyncio.Event()
@@ -93,8 +103,8 @@ class AbstractBlob:
         self.added_on = added_on or time.time()
         self.is_mine = is_mine
 
-        if not is_valid_blobhash(blob_hash):
-            raise InvalidBlobHashError(blob_hash)
+        if not self.blob_directory or not os.path.isdir(self.blob_directory):
+            raise OSError(f"cannot create blob in directory: '{self.blob_directory}'")
 
     def __del__(self):
         if self.writers or self.readers:
@@ -187,7 +197,7 @@ class AbstractBlob:
 
     @classmethod
     async def create_from_unencrypted(
-        cls, loop: asyncio.AbstractEventLoop, blob_dir: typing.Optional[str], key: bytes, iv: bytes,
+        cls, loop: asyncio.AbstractEventLoop, blob_manager: 'BlobManager', key: bytes, iv: bytes,
         unencrypted: bytes, blob_num: int, added_on: int, is_mine: bool,
         blob_completed_callback: typing.Optional[typing.Callable[['AbstractBlob'], None]] = None,
     ) -> BlobInfo:
@@ -197,7 +207,7 @@ class AbstractBlob:
 
         blob_bytes, blob_hash = encrypt_blob_bytes(key, iv, unencrypted)
         length = len(blob_bytes)
-        blob = cls(loop, blob_hash, length, blob_completed_callback, blob_dir, added_on, is_mine)
+        blob = cls(loop, blob_hash, length, blob_completed_callback, blob_manager, added_on, is_mine)
         writer = blob.get_blob_writer()
         writer.write(blob_bytes)
         await blob.verified.wait()
@@ -259,10 +269,11 @@ class BlobBuffer(AbstractBlob):
     def __init__(
         self, loop: asyncio.AbstractEventLoop, blob_hash: str, length: typing.Optional[int] = None,
         blob_completed_callback: typing.Optional[typing.Callable[['AbstractBlob'], asyncio.Task]] = None,
-        blob_directory: typing.Optional[str] = None, added_on: typing.Optional[int] = None, is_mine: bool = False
+        blob_manager: typing.Optional['BlobManager'] = None,
+        added_on: typing.Optional[int] = None, is_mine: bool = False
     ):
         self._verified_bytes: typing.Optional[BytesIO] = None
-        super().__init__(loop, blob_hash, length, blob_completed_callback, blob_directory, added_on, is_mine)
+        super().__init__(loop, blob_hash, length, blob_completed_callback, blob_manager, added_on, is_mine)
 
     @contextlib.contextmanager
     def _reader_context(self) -> typing.ContextManager[typing.BinaryIO]:
@@ -302,11 +313,10 @@ class BlobFile(AbstractBlob):
     def __init__(
         self, loop: asyncio.AbstractEventLoop, blob_hash: str, length: typing.Optional[int] = None,
         blob_completed_callback: typing.Optional[typing.Callable[['AbstractBlob'], asyncio.Task]] = None,
-        blob_directory: typing.Optional[str] = None, added_on: typing.Optional[int] = None, is_mine: bool = False
+        blob_manager: typing.Optional['BlobManager'] = None,
+        added_on: typing.Optional[int] = None, is_mine: bool = False
     ):
-        super().__init__(loop, blob_hash, length, blob_completed_callback, blob_directory, added_on, is_mine)
-        if not blob_directory or not os.path.isdir(blob_directory):
-            raise OSError(f"invalid blob directory '{blob_directory}'")
+        super().__init__(loop, blob_hash, length, blob_completed_callback, blob_manager, added_on, is_mine)
         self.file_path = os.path.join(self.blob_directory, self.blob_hash)
         if self.file_exists:
             file_size = int(os.stat(self.file_path).st_size)
@@ -355,12 +365,10 @@ class BlobFile(AbstractBlob):
 
     @classmethod
     async def create_from_unencrypted(
-        cls, loop: asyncio.AbstractEventLoop, blob_dir: typing.Optional[str], key: bytes, iv: bytes,
+        cls, loop: asyncio.AbstractEventLoop, blob_manager: 'BlobManager', key: bytes, iv: bytes,
         unencrypted: bytes, blob_num: int, added_on: float, is_mine: bool,
         blob_completed_callback: typing.Optional[typing.Callable[['AbstractBlob'], asyncio.Task]] = None
     ) -> BlobInfo:
-        if not blob_dir or not os.path.isdir(blob_dir):
-            raise OSError(f"cannot create blob in directory: '{blob_dir}'")
         return await super().create_from_unencrypted(
-            loop, blob_dir, key, iv, unencrypted, blob_num, added_on, is_mine, blob_completed_callback
+            loop, blob_manager, key, iv, unencrypted, blob_num, added_on, is_mine, blob_completed_callback
         )

--- a/lbry/blob/blob_manager.py
+++ b/lbry/blob/blob_manager.py
@@ -2,8 +2,16 @@ import os
 import typing
 import asyncio
 import logging
+from collections import defaultdict
 from lbry.utils import LRUCacheWithMetrics
-from lbry.blob.blob_file import is_valid_blobhash, BlobFile, BlobBuffer, AbstractBlob
+from lbry.blob import BLOBHASH_LENGTH
+from lbry.blob.blob_file import (
+    HEXMATCH,
+    is_valid_blobhash,
+    BlobFile,
+    BlobBuffer,
+    AbstractBlob,
+)
 from lbry.stream.descriptor import StreamDescriptor
 from lbry.connection_manager import ConnectionManager
 
@@ -16,16 +24,19 @@ log = logging.getLogger(__name__)
 
 
 class BlobManager:
-    def __init__(self, loop: asyncio.AbstractEventLoop, blob_dir: str, storage: 'SQLiteStorage', config: 'Config',
+    def __init__(self, loop: asyncio.AbstractEventLoop, blob_dirs: typing.List[str],
+                 storage: 'SQLiteStorage', config: 'Config',
                  node_data_store: typing.Optional['DictDataStore'] = None):
         """
         This class stores blobs on the hard disk
 
-        blob_dir - directory where blobs are stored
+        blob_dirs - directories where blobs are stored
         storage - SQLiteStorage object
         """
         self.loop = loop
-        self.blob_dir = blob_dir
+        self.blob_dirs = defaultdict(list)
+        self.blob_dirs.update({ '': blob_dirs if isinstance(blob_dirs, list) else [blob_dirs]})
+        self.blob_dirs_max_prefix_len = 0  # Maximum key length in "blob_dirs" dictionary.
         self.storage = storage
         self._node_data_store = node_data_store
         self.completed_blob_hashes: typing.Set[str] = set() if not self._node_data_store\
@@ -36,14 +47,37 @@ class BlobManager:
             self.config.blob_lru_cache_size)
         self.connection_manager = ConnectionManager(loop)
 
+    def _blob_dir(self, blob_hash: str) -> typing.Tuple[str, bool]:
+        """
+        Locate blob directory matching longest prefix of blob hash.
+        An existing blob is preferred, even if it doesn't reside in
+        the directory with longest prefix.
+        """
+        best_dir = None
+        for prefix in [blob_hash[:i] for i in range(min(len(blob_hash), self.blob_dirs_max_prefix_len), -1, -1)]:
+            if prefix in self.blob_dirs:
+                if not best_dir:
+                    best_dir = self.blob_dirs[prefix][0]
+                for path in self.blob_dirs[prefix]:
+                    if os.path.isfile(os.path.join(path, blob_hash)):
+                        #print(f'blob {blob_hash} FOUND at location: {path}')
+                        return path, True
+        #print(f'blob {blob_hash} has BEST location: {best_dir}')
+        return best_dir, False
+
+
     def _get_blob(self, blob_hash: str, length: typing.Optional[int] = None, is_mine: bool = False):
-        if self.config.save_blobs or (
-                is_valid_blobhash(blob_hash) and os.path.isfile(os.path.join(self.blob_dir, blob_hash))):
+        if self.config.save_blobs:
             return BlobFile(
-                self.loop, blob_hash, length, self.blob_completed, self.blob_dir, is_mine=is_mine
+                self.loop, blob_hash, length, self.blob_completed, self, is_mine=is_mine
+            )
+        _, blob_found = self._blob_dir(blob_hash)
+        if blob_found:
+            return BlobFile(
+                self.loop, blob_hash, length, self.blob_completed, self, is_mine=is_mine
             )
         return BlobBuffer(
-            self.loop, blob_hash, length, self.blob_completed, self.blob_dir, is_mine=is_mine
+            self.loop, blob_hash, length, self.blob_completed, self, is_mine=is_mine
         )
 
     def get_blob(self, blob_hash, length: typing.Optional[int] = None, is_mine: bool = False):
@@ -65,21 +99,39 @@ class BlobManager:
     def is_blob_verified(self, blob_hash: str, length: typing.Optional[int] = None) -> bool:
         if not is_valid_blobhash(blob_hash):
             raise ValueError(blob_hash)
-        if not os.path.isfile(os.path.join(self.blob_dir, blob_hash)):
+        _, blob_found = self._blob_dir(blob_hash)
+        if not blob_found:
             return False
         if blob_hash in self.blobs:
             return self.blobs[blob_hash].get_is_verified()
         return self._get_blob(blob_hash, length).get_is_verified()
 
-    async def setup(self) -> bool:
-        def get_files_in_blob_dir() -> typing.Set[str]:
-            if not self.blob_dir:
-                return set()
-            return {
-                item.name for item in os.scandir(self.blob_dir) if is_valid_blobhash(item.name)
-            }
+    def list_blobs(self, paths = None, prefix = '', setup=False):
+        """
+        Recursively search for blob files within path(s) and subdirectories.
+        When setup=True, subdirectories which are candidates for blob storage
+        are added to the "self.blob_dirs" dictionary.
+        """
+        blobfiles = set()
+        subdirs = defaultdict(list)
+        for path in paths if paths is not None else self.blob_dirs[prefix]:
+            with os.scandir(path) as entries:
+                for item in entries:
+                    if item.is_file() and is_valid_blobhash(item.name):
+                        blobfiles.add(item.name)
+                    elif item.is_dir() and len(prefix+item.name) < BLOBHASH_LENGTH and HEXMATCH.match(item.name):
+                        subdirs[item.name].append(item.path)
+        # Recursively process subdirectories which may also contain blobs.
+        for name, subdir_paths in subdirs.items():
+            if setup:
+                self.blob_dirs[prefix+name] = subdir_paths
+                self.blob_dirs_max_prefix_len = max(self.blob_dirs_max_prefix_len, len(prefix+name))
+            blobfiles.update(self.list_blobs(paths=subdir_paths, prefix=prefix+name, setup=setup))
+        return blobfiles
 
-        in_blobfiles_dir = await self.loop.run_in_executor(None, get_files_in_blob_dir)
+    async def setup(self) -> bool:
+        in_blobfiles_dir = await self.loop.run_in_executor(None, lambda: self.list_blobs(setup=True))
+        #print(f'blob dirs: {self.blob_dirs}')
         to_add = await self.storage.sync_missing_blobs(in_blobfiles_dir)
         if to_add:
             self.completed_blob_hashes.update(to_add)
@@ -97,7 +149,7 @@ class BlobManager:
         self.completed_blob_hashes.clear()
 
     def get_stream_descriptor(self, sd_hash):
-        return StreamDescriptor.from_stream_descriptor_blob(self.loop, self.blob_dir, self.get_blob(sd_hash))
+        return StreamDescriptor.from_stream_descriptor_blob(self.loop, self, self.get_blob(sd_hash))
 
     def blob_completed(self, blob: AbstractBlob) -> asyncio.Task:
         if blob.blob_hash is None:
@@ -133,8 +185,9 @@ class BlobManager:
             raise Exception("invalid blob hash to delete")
 
         if blob_hash not in self.blobs:
-            if self.blob_dir and os.path.isfile(os.path.join(self.blob_dir, blob_hash)):
-                os.remove(os.path.join(self.blob_dir, blob_hash))
+            blob_dir, blob_found = self._blob_dir(blob_hash)
+            if blob_dir and blob_found:
+                os.remove(os.path.join(blob_dir, blob_hash))
         else:
             self.blobs.pop(blob_hash).delete()
             if blob_hash in self.completed_blob_hashes:

--- a/lbry/extras/daemon/components.py
+++ b/lbry/extras/daemon/components.py
@@ -241,6 +241,9 @@ class BlobComponent(Component):
             if not os.path.isdir(blob_dir):
                 os.mkdir(blob_dir)
                 #print(f'created blob dir: {blob_dir}')
+            # TODO: Should subdir setup be done for new or empty blob dirs only?
+            # Setting up the subdirs will not relocate existing blobs and
+            # will just slow down lookups until & unless the subdirs fill up.
             setup_subdirs(blob_dir, 3)
 
         self.blob_manager = BlobManager(self.component_manager.loop, blob_dirs, storage, self.conf, data_store)

--- a/lbry/stream/downloader.py
+++ b/lbry/stream/downloader.py
@@ -81,7 +81,7 @@ class StreamDownloader:
 
         # parse the descriptor
         self.descriptor = await StreamDescriptor.from_stream_descriptor_blob(
-            self.loop, self.blob_manager.blob_dir, sd_blob
+            self.loop, self.blob_manager, sd_blob
         )
         log.info("loaded stream manifest %s", self.sd_hash)
 

--- a/lbry/stream/reflector/server.py
+++ b/lbry/stream/reflector/server.py
@@ -96,7 +96,7 @@ class ReflectorServerProtocol(asyncio.Protocol):
                 try:
                     await asyncio.wait_for(self.sd_blob.verified.wait(), 30)
                     self.descriptor = await StreamDescriptor.from_stream_descriptor_blob(
-                        self.loop, self.blob_manager.blob_dir, self.sd_blob
+                        self.loop, self.blob_manager, self.sd_blob
                     )
                     self.send_response({"received_sd_blob": True})
                 except asyncio.TimeoutError:
@@ -109,7 +109,7 @@ class ReflectorServerProtocol(asyncio.Protocol):
                     self.writer = None
             else:
                 self.descriptor = await StreamDescriptor.from_stream_descriptor_blob(
-                    self.loop, self.blob_manager.blob_dir, self.sd_blob
+                    self.loop, self.blob_manager, self.sd_blob
                 )
                 self.incoming.clear()
                 self.not_incoming.set()

--- a/lbry/stream/stream_manager.py
+++ b/lbry/stream/stream_manager.py
@@ -78,7 +78,7 @@ class StreamManager(SourceManager):
             sd_blob = self.blob_manager.get_blob(sd_hash)
             blobs = await self.storage.get_blobs_for_stream(stream_hash)
             descriptor = await StreamDescriptor.recover(
-                self.blob_manager.blob_dir, sd_blob, stream_hash, stream_name, suggested_file_name, key, blobs
+                self.blob_manager, sd_blob, stream_hash, stream_name, suggested_file_name, key, blobs
             )
             if not descriptor:
                 return
@@ -236,7 +236,7 @@ class StreamManager(SourceManager):
     async def create(self, file_path: str, key: Optional[bytes] = None,
                      iv_generator: Optional[typing.Generator[bytes, None, None]] = None) -> ManagedStream:
         descriptor = await StreamDescriptor.create_stream(
-            self.loop, self.blob_manager.blob_dir, file_path, key=key, iv_generator=iv_generator,
+            self.loop, self.blob_manager, file_path, key=key, iv_generator=iv_generator,
             blob_completed_callback=self.blob_manager.blob_completed
         )
         await self.storage.store_stream(

--- a/lbry/wallet/orchstr8/node.py
+++ b/lbry/wallet/orchstr8/node.py
@@ -199,7 +199,8 @@ class WalletNode:
             cleanup and self.cleanup()
 
     def cleanup(self):
-        shutil.rmtree(self.data_path, ignore_errors=True)
+        log.warning("skipping cleanup of data_path: %s", self.data_path)
+        #shutil.rmtree(self.data_path, ignore_errors=True)
 
 
 class SPVNode:

--- a/tests/integration/datanetwork/test_file_commands.py
+++ b/tests/integration/datanetwork/test_file_commands.py
@@ -636,7 +636,7 @@ class DiskSpaceManagement(CommandTestCase):
 class TestBackgroundDownloaderComponent(CommandTestCase):
     async def get_blobs_from_sd_blob(self, sd_blob):
         descriptor = await StreamDescriptor.from_stream_descriptor_blob(
-            asyncio.get_running_loop(), self.daemon.blob_manager.blob_dir, sd_blob
+            asyncio.get_running_loop(), self.daemon.blob_manager, sd_blob
         )
         return descriptor.blobs
 

--- a/tests/integration/datanetwork/test_streaming.py
+++ b/tests/integration/datanetwork/test_streaming.py
@@ -31,10 +31,10 @@ class RangeRequests(CommandTestCase):
         self.data = data
         await self.stream_create('foo', '0.01', data=self.data, file_size=file_size)
         if save_blobs:
-            self.assertGreater(len(os.listdir(self.daemon.blob_manager.blob_dir)), 1)
+            self.assertGreater(len(self.daemon.blob_manager.list_blobs()), 1)
         await (await self.daemon.jsonrpc_file_list())['items'][0].fully_reflected.wait()
         await self.daemon.jsonrpc_file_delete(delete_from_download_dir=True, claim_name='foo')
-        self.assertEqual(0, len(os.listdir(self.daemon.blob_manager.blob_dir)))
+        self.assertEqual(0, len(self.daemon.blob_manager.list_blobs()))
         # await self._restart_stream_manager()
         await self.daemon.streaming_runner.setup()
         site = aiohttp.web.TCPSite(self.daemon.streaming_runner, self.daemon.conf.streaming_host,
@@ -313,20 +313,20 @@ class RangeRequests(CommandTestCase):
         self.daemon.conf.save_blobs = True
         blobs_in_stream = (await self.daemon.jsonrpc_file_list())['items'][0].blobs_in_stream
         sd_hash = (await self.daemon.jsonrpc_file_list())['items'][0].sd_hash
-        start_file_count = len(os.listdir(self.daemon.blob_manager.blob_dir))
+        start_file_count = len(self.daemon.blob_manager.list_blobs())
         await self._test_range_requests()
-        self.assertEqual(start_file_count + blobs_in_stream, len(os.listdir(self.daemon.blob_manager.blob_dir)))
+        self.assertEqual(start_file_count + blobs_in_stream, len(self.daemon.blob_manager.list_blobs()))
         self.assertEqual(0, (await self.daemon.jsonrpc_file_list())['items'][0].blobs_remaining)
 
         # switch back
         self.daemon.conf.save_blobs = False
         await self._test_range_requests()
-        self.assertEqual(start_file_count + blobs_in_stream, len(os.listdir(self.daemon.blob_manager.blob_dir)))
+        self.assertEqual(start_file_count + blobs_in_stream, len(self.daemon.blob_manager.list_blobs()))
         self.assertEqual(0, (await self.daemon.jsonrpc_file_list())['items'][0].blobs_remaining)
         await self.daemon.jsonrpc_file_delete(delete_from_download_dir=True, sd_hash=sd_hash)
-        self.assertEqual(start_file_count, len(os.listdir(self.daemon.blob_manager.blob_dir)))
+        self.assertEqual(start_file_count, len(self.daemon.blob_manager.list_blobs()))
         await self._test_range_requests()
-        self.assertEqual(start_file_count, len(os.listdir(self.daemon.blob_manager.blob_dir)))
+        self.assertEqual(start_file_count, len(self.daemon.blob_manager.list_blobs()))
         self.assertEqual(blobs_in_stream, (await self.daemon.jsonrpc_file_list())['items'][0].blobs_remaining)
 
     async def test_file_save_streaming_only_save_blobs(self):
@@ -400,7 +400,7 @@ class RangeRequestsLRUCache(CommandTestCase):
         await self.stream_create('foo', '0.01', data=self.data, file_size=0)
         await (await self.daemon.jsonrpc_file_list())['items'][0].fully_reflected.wait()
         await self.daemon.jsonrpc_file_delete(delete_from_download_dir=True, claim_name='foo')
-        self.assertEqual(0, len(os.listdir(self.daemon.blob_manager.blob_dir)))
+        self.assertEqual(0, len(self.daemon.blob_manager.list_blobs()))
 
         await self.daemon.streaming_runner.setup()
         site = aiohttp.web.TCPSite(self.daemon.streaming_runner, self.daemon.conf.streaming_host,

--- a/tests/unit/blob/test_blob_manager.py
+++ b/tests/unit/blob/test_blob_manager.py
@@ -35,7 +35,7 @@ class TestBlobManager(AsyncioTestCase):
         # add a blob file
         blob_hash = "7f5ab2def99f0ddd008da71db3a3772135f4002b19b7605840ed1034c8955431bd7079549e65e6b2a3b9c17c773073ed"
         blob_bytes = b'1' * ((2 * 2 ** 20) - 1)
-        with open(os.path.join(self.blob_manager.blob_dir, blob_hash), 'wb') as f:
+        with open(os.path.join(self.blob_manager._blob_dir(blob_hash)[0], blob_hash), 'wb') as f:
             f.write(blob_bytes)
 
         # it should not have been added automatically on startup
@@ -57,7 +57,7 @@ class TestBlobManager(AsyncioTestCase):
         self.blob_manager.stop()
 
         # manually delete the blob file and restart the blob manager
-        os.remove(os.path.join(self.blob_manager.blob_dir, blob_hash))
+        os.remove(os.path.join(self.blob_manager._blob_dir(blob_hash)[0], blob_hash))
         await self.blob_manager.setup()
         self.assertSetEqual(self.blob_manager.completed_blob_hashes, set())
 

--- a/tests/unit/database/test_SQLiteStorage.py
+++ b/tests/unit/database/test_SQLiteStorage.py
@@ -86,7 +86,7 @@ class StorageTest(AsyncioTestCase):
     async def store_fake_stream(self, stream_hash, blobs=None, file_name="fake_file", key="DEADBEEF"):
         blobs = blobs or [BlobInfo(1, 100, "DEADBEEF", 0, random_lbry_hash())]
         descriptor = StreamDescriptor(
-            asyncio.get_event_loop(), self.blob_dir, file_name, key, file_name, blobs, stream_hash
+            asyncio.get_event_loop(), self.blob_manager, file_name, key, file_name, blobs, stream_hash
         )
         sd_blob = await descriptor.make_sd_blob()
         await self.storage.store_stream(sd_blob, descriptor)

--- a/tests/unit/stream/test_managed_stream.py
+++ b/tests/unit/stream/test_managed_stream.py
@@ -24,7 +24,7 @@ class TestManagedStream(BlobExchangeTestBase):
         file_path = os.path.join(self.server_dir, file_name)
         with open(file_path, 'wb') as f:
             f.write(self.stream_bytes)
-        descriptor = await StreamDescriptor.create_stream(self.loop, self.server_blob_manager.blob_dir, file_path)
+        descriptor = await StreamDescriptor.create_stream(self.loop, self.server_blob_manager, file_path)
         descriptor.suggested_file_name = file_name
         descriptor.stream_hash = descriptor.get_stream_hash()
         self.sd_hash = descriptor.sd_hash = descriptor.calculate_sd_hash()
@@ -166,16 +166,16 @@ class TestManagedStream(BlobExchangeTestBase):
         descriptor = await self.create_stream(blobs)
 
         # copy blob files
-        shutil.copy(os.path.join(self.server_blob_manager.blob_dir, self.sd_hash),
-                    os.path.join(self.client_blob_manager.blob_dir, self.sd_hash))
+        shutil.copy(os.path.join(self.server_blob_manager._blob_dir(self.sd_hash)[0], self.sd_hash),
+                    os.path.join(self.client_blob_manager._blob_dir(self.sd_hash)[0], self.sd_hash))
         self.stream = ManagedStream(self.loop, self.client_config, self.client_blob_manager, self.sd_hash,
                                     self.client_dir)
 
         for blob_info in descriptor.blobs[:-1]:
-            shutil.copy(os.path.join(self.server_blob_manager.blob_dir, blob_info.blob_hash),
-                        os.path.join(self.client_blob_manager.blob_dir, blob_info.blob_hash))
+            shutil.copy(os.path.join(self.server_blob_manager._blob_dir(blob_info.blob_hash)[0], blob_info.blob_hash),
+                        os.path.join(self.client_blob_manager._blob_dir(blob_info.blob_hash)[0], blob_info.blob_hash))
             if corrupt and blob_info.length == MAX_BLOB_SIZE:
-                with open(os.path.join(self.client_blob_manager.blob_dir, blob_info.blob_hash), "rb+") as handle:
+                with open(os.path.join(self.client_blob_manager._blob_dir(blob_info.blob_hash)[0], blob_info.blob_hash), "rb+") as handle:
                     handle.truncate()
                     handle.flush()
         await self.stream.save_file()

--- a/tests/unit/stream/test_stream_manager.py
+++ b/tests/unit/stream/test_stream_manager.py
@@ -136,7 +136,7 @@ class TestStreamManager(BlobExchangeTestBase):
         with open(file_path, 'wb') as f:
             f.write(os.urandom(20000000))
         descriptor = await StreamDescriptor.create_stream(
-            self.loop, self.server_blob_manager.blob_dir, file_path, old_sort=old_sort
+            self.loop, self.server_blob_manager, file_path, old_sort=old_sort
         )
         self.sd_hash = descriptor.sd_hash
         self.mock_wallet, self.uri = await get_mock_wallet(self.sd_hash, self.client_storage, self.client_wallet_dir,
@@ -453,7 +453,7 @@ class TestStreamManager(BlobExchangeTestBase):
         self.client_blob_manager.stop()
         # partial removal, only sd blob is missing.
         # in this case, we recover the sd blob while the other blobs are kept untouched as 'finished'
-        os.remove(os.path.join(self.client_blob_manager.blob_dir, stream.sd_hash))
+        os.remove(os.path.join(self.client_blob_manager._blob_dir(stream.sd_hash)[0], stream.sd_hash))
         await self.client_blob_manager.setup()
         await self.stream_manager.start()
         self.assertEqual(1, len(self.stream_manager.streams))
@@ -470,9 +470,9 @@ class TestStreamManager(BlobExchangeTestBase):
 
         # full removal, check that status is preserved (except sd blob, which was written)
         self.client_blob_manager.stop()
-        os.remove(os.path.join(self.client_blob_manager.blob_dir, stream.sd_hash))
+        os.remove(os.path.join(self.client_blob_manager._blob_dir(stream.sd_hash)[0], stream.sd_hash))
         for blob in stream.descriptor.blobs[:-1]:
-            os.remove(os.path.join(self.client_blob_manager.blob_dir, blob.blob_hash))
+            os.remove(os.path.join(self.client_blob_manager._blob_dir(blob.blob_hash)[0], blob.blob_hash))
         await self.client_blob_manager.setup()
         await self.stream_manager.start()
         for blob_hash in [b.blob_hash for b in stream.descriptor.blobs[:-1]]:


### PR DESCRIPTION
Fixes #3704

Work-in-progress... Need to test `--blob-dirs` option.

The idea here is that `<data_dir>/blobfiles` will continue to exist, but people can add more blob dirs using `--blob-dirs`. New blobs will be place in the first dir of the list.