### PR TITLE
save a reference to created tasks, to avoid tasks disappearing

### DIFF
--- a/lbry/blob/disk_space_manager.py
+++ b/lbry/blob/disk_space_manager.py
@@ -43,7 +43,7 @@ class DiskSpaceManager:
             space_used_mb = space_used_mb['content_storage'] + space_used_mb['private_storage']
         storage_limit_mb = self.config.network_storage_limit if is_network_blob else self.config.blob_storage_limit
         if self.analytics:
-            asyncio.create_task(
+            task = asyncio.create_task(
                 self.analytics.send_disk_space_used(space_used_mb, storage_limit_mb, is_network_blob)
             )
         delete = []

--- a/lbry/extras/daemon/daemon.py
+++ b/lbry/extras/daemon/daemon.py
@@ -1383,7 +1383,7 @@ class Daemon(metaclass=JSONRPCServerType):
                 ])
             else:
                 for new_account in added_accounts:
-                    asyncio.create_task(self.ledger.subscribe_account(new_account))
+                    task = asyncio.create_task(self.ledger.subscribe_account(new_account))
         wallet.save()
         return await self.jsonrpc_wallet_export(password=password, wallet_id=wallet_id)
 
@@ -2001,7 +2001,7 @@ class Daemon(metaclass=JSONRPCServerType):
                     ])
                 else:
                     for new_account in added_accounts:
-                        asyncio.create_task(self.ledger.subscribe_account(new_account))
+                        task = asyncio.create_task(self.ledger.subscribe_account(new_account))
             wallet_changed = True
         if wallet.preferences.get(ENCRYPT_ON_DISK, False) and password != wallet.encryption_password:
             wallet.encryption_password = password

--- a/lbry/wallet/ledger.py
+++ b/lbry/wallet/ledger.py
@@ -334,7 +334,7 @@ class Ledger(metaclass=LedgerRegistry):
             self.headers.open()
         ]))
         fully_synced = self.on_ready.first
-        asyncio.create_task(self.network.start())
+        task = asyncio.create_task(self.network.start())
         await self.network.on_connected.first
         async with self._header_processing_lock:
             await self._update_tasks.add(self.initial_headers_sync())

--- a/tests/unit/components/test_component_manager.py
+++ b/tests/unit/components/test_component_manager.py
@@ -170,7 +170,7 @@ class TestComponentManagerProperStart(AdvanceTimeTestCase):
         )
 
     async def test_proper_starting_of_components(self):
-        asyncio.create_task(self.component_manager.start())
+        task = asyncio.create_task(self.component_manager.start())
 
         await self.advance(0)
         self.assertTrue(self.component_manager.get_component('wallet').running)
@@ -188,7 +188,7 @@ class TestComponentManagerProperStart(AdvanceTimeTestCase):
         self.assertTrue(self.component_manager.get_component('file_manager').running)
 
     async def test_proper_stopping_of_components(self):
-        asyncio.create_task(self.component_manager.start())
+        task = asyncio.create_task(self.component_manager.start())
         await self.advance(0)
         await self.advance(1)
         await self.advance(1)
@@ -196,7 +196,7 @@ class TestComponentManagerProperStart(AdvanceTimeTestCase):
         self.assertTrue(self.component_manager.get_component('blob_manager').running)
         self.assertTrue(self.component_manager.get_component('file_manager').running)
 
-        asyncio.create_task(self.component_manager.stop())
+        task = asyncio.create_task(self.component_manager.stop())
         await self.advance(0)
         self.assertFalse(self.component_manager.get_component('file_manager').running)
         self.assertTrue(self.component_manager.get_component('blob_manager').running)


### PR DESCRIPTION
This change saves references for created tasks to avoid tasks disappearing. 

> Save a reference to the result of this function, to avoid a task disappearing mid-execution. The event loop only keeps weak references to tasks. A task that isn’t referenced elsewhere may get garbage collected at any time, even before it’s done.
>
> [python docs](https://docs.python.org/3/library/asyncio-task.html#asyncio.create_task)

Please review the link: https://textual.textualize.io/blog/2023/02/11/the-heisenbug-lurking-in-your-async-code/
