### PR TITLE
Bump version to 0.114.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,3 +54,16 @@ The documentation for the API can be found [here](https://lbry.tech/api/sdk).
 Daemon defaults, ports, and other settings are documented [here](https://lbry.tech/resources/daemon-settings).
 
 Settings can be configured using a daemon-settings.yml file. An example can be found [here](https://github.com/lbryio/lbry-sdk/blob/master/example_daemon_settings.yml).
+
+## Troubleshooting
+
+### Error: unsupported hash type 'ripemd160'
+
+If you see this error when running `lbrynet start`, it likely means your OpenSSL or Python installation is missing RIPEMD160 support.
+
+To fix it:
+
+- Ensure you are using a version of Python compiled with OpenSSL support.
+- On Ubuntu/Debian, try: `sudo apt install libssl-dev` and reinstall Python.
+- Alternatively, use a precompiled Python version (e.g., via `pyenv install 3.8.18` after `libssl-dev` is installed).
+

--- a/lbry/__init__.py
+++ b/lbry/__init__.py
@@ -1,2 +1,2 @@
-__version__ = "0.113.0"
+__version__ = "0.114.0"
 version = tuple(map(int, __version__.split('.')))  # pylint: disable=invalid-name

--- a/lbry/crypto/hash.py
+++ b/lbry/crypto/hash.py
@@ -15,9 +15,16 @@ def sha512(x):
 
 def ripemd160(x):
     """ Simple wrapper of hashlib ripemd160. """
-    h = hashlib.new('ripemd160')
+    try:
+        h = hashlib.new('ripemd160')
+    except ValueError as e:
+        raise RuntimeError(
+            "Your Python/OpenSSL installation does not support RIPEMD160. "
+            "Try reinstalling Python with full OpenSSL support."
+        ) from e
     h.update(x)
     return h.digest()
+
 
 
 def double_sha256(x):


### PR DESCRIPTION
This PR bumps the version to 0.114.0. After this PR, the commit should be tagged as `v0.114.0` and a release should be made.